### PR TITLE
Enable hardware CRC in rocksdb

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -117,6 +117,14 @@ fn build_rocksdb() {
         config.flag("-Wno-unused-parameter");
     }
 
+    if cfg!(target_arch = "x86_64" ) {
+        // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
+        // only available since Intel Nehalem (about 2010) and AMD Bulldozer
+        // (about 2011).
+        config.flag("-msse4.2");
+        config.define("HAVE_SSE42", Some("1"));
+    }
+
     for file in lib_sources {
         let file = "rocksdb/".to_string() + file;
         config.file(&file);


### PR DESCRIPTION
This requires passing -msse4.2 and -DHAVE_SSE42 to the compiler.
You can check with:
  cargo test --release && grep CRC _rust*/LOG
Previously, this would output:
  Fast CRC32 supported: Not supported on x86
Now it shows:
  Fast CRC32 supported: Supported on x86

---

More generally, there may be other compiler flag differences between the Rust build and the upstream `make static_lib` build. I'm including below the full set of differences in my builds. I don't know what all of these are for, and I'm a bit worried we're missing out on other important ones. Thoughts?

```
Flags on Mac with Rust but not make:
-Irocksdb/
-Irocksdb/include/
-Irocksdb/third-party/gtest-1.7.0/fused-src/
-Isnappy/
-O3
-fPIC
-fdata-sections
-ffunction-sections
-m64
-msse4.2
c++

Flags on Mac with make but not Rust:
-DBZIP2
-DGFLAGS
-DHAVE_PCLMUL
-DLZ4
-DROCKSDB_BACKTRACE
-DROCKSDB_SUPPORT_THREAD_LOCAL
-DZLIB
-DZSTD
-I./include
-O2
-W
-Werror
-Wno-missing-field-initializers
-Wnon-virtual-dtor
-Woverloaded-virtual
-Wshadow
-Wshorten-64-to-32
-Wsign-compare
-fno-omit-frame-pointer
-fno-rtti
-g
-isystem=./third-party/gtest-1.7.0/fused-src
-march=native
-momit-leaf-frame-pointer
g++

Flags on Linux with Rust but not make:
-Irocksdb/
-Irocksdb/include/
-Irocksdb/third-party/gtest-1.7.0/fused-src/
-Isnappy/
-O3
-fPIC
-fdata-sections
-ffunction-sections
-m64
-msse4.2
c++

Flags on Linux with make but not Rust:
-DBZIP2
-DGFLAGS
-DHAVE_PCLMUL
-DLZ4
-DROCKSDB_BACKTRACE
-DROCKSDB_FALLOCATE_PRESENT
-DROCKSDB_MALLOC_USABLE_SIZE
-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX
-DROCKSDB_RANGESYNC_PRESENT
-DROCKSDB_SCHED_GETCPU_PRESENT
-DROCKSDB_SUPPORT_THREAD_LOCAL
-DZLIB
-DZSTD
-I./include
-O2
-W
-Werror
-Wno-missing-field-initializers
-Wnon-virtual-dtor
-Woverloaded-virtual
-Wshadow
-Wsign-compare
-fno-builtin-memcmp
-fno-omit-frame-pointer
-fno-rtti
-g
-isystem=./third-party/gtest-1.7.0/fused-src
-march=native
-momit-leaf-frame-pointer
g++
```