### PR TITLE
Add get_cf_by_name method to `Snapshot`

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -838,6 +838,10 @@ impl DB {
         self.get_cf_opt(cf, key, &ReadOptions::default())
     }
 
+    pub fn get_cf_by_name<T: AsRef<str>>(&self, name: T, key: &[u8]) -> Option<Result<Option<DBVector>, Error>> {
+        Some(self.get_cf(self.cf_handle(name.as_ref())?, key))
+    }
+
     pub fn create_cf(&mut self, name: &str, opts: &Options) -> Result<ColumnFamily, Error> {
         let cname = match CString::new(name.as_bytes()) {
             Ok(c) => c,

--- a/src/db.rs
+++ b/src/db.rs
@@ -838,8 +838,8 @@ impl DB {
         self.get_cf_opt(cf, key, &ReadOptions::default())
     }
 
-    pub fn get_cf_by_name<T: AsRef<str>>(&self, name: T, key: &[u8]) -> Option<Result<Option<DBVector>, Error>> {
-        Some(self.get_cf(self.cf_handle(name.as_ref())?, key))
+    pub fn get_cf_by_name<T: AsRef<str>>(&self, name: T, key: &[u8]) -> Result<Option<DBVector>, Error> {
+        self.get_cf(self.cf_handle(name.as_ref())?, key)
     }
 
     pub fn create_cf(&mut self, name: &str, opts: &Options) -> Result<ColumnFamily, Error> {


### PR DESCRIPTION
Right now to get data from a column family in a `Snapshot` you need the handle (`ColumnFamily`). To get a handle, you must consult the `DB` object with column family name.
This PR simplifies the process by adding `get_cf_by_name` method which allows you to directly access data in a column family with a name instead of handle.