### PR TITLE
Support linking to other compression libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ exclude = [
 [features]
 default = []
 valgrind = []
+snappy = ["librocksdb-sys/snappy"]
+lz4 = ["librocksdb-sys/lz4"]
+bzip2 = ["librocksdb-sys/bzip2"]
+zlib = ["librocksdb-sys/zlib"]
 
 [dependencies]
 libc = "0.2"

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -12,8 +12,12 @@ build = "build.rs"
 links = "rocksdb"
 
 [features]
-default = [ "static" ]
+default = ["static", "snappy"]
 static = []
+snappy = []
+lz4 = []
+bzip2 = []
+zlib = []
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
I'm not sure what the best way to do this would be, but this is one approach at least. It adds a feature for each compression method, and defaults to using `snappy`. For each feature the `librocksdb-sys` build script then tries to dynamically link that compression method, through e.g. `cargo:rustc-link-lib=lz4`.

Another option would be to try to detect this automatically, e.g. similar to what [rocksdb-sys does here](https://github.com/jsgf/rocksdb-sys/blob/master/build.rs). `rockdb-sys` does so by relying on RocksDB's own makefile config though, which wouldn't be possible for us.

A third option would be to add sys packages for each of the compression methods, such as [lz4-rs](https://github.com/bozaro/lz4-rs), instead of trying to link to the system libraries.

Let me know what you think - I'd be happy to update the docs as well.