### PR TITLE
Expose keep_log_file_num option

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1113,6 +1113,13 @@ impl Options {
             ffi::rocksdb_options_set_skip_stats_update_on_db_open(self.inner, skip as c_uchar);
         }
     }
+
+    /// Specify the maximal number of info log files to be kept.
+    pub fn set_keep_log_file_num(&mut self, nfiles: usize) {
+        unsafe {
+            ffi::rocksdb_options_set_keep_log_file_num(self.inner, nfiles);
+        }
+    }
 }
 
 impl Default for Options {


### PR DESCRIPTION
This should allow decreasing the [default value](https://github.com/facebook/rocksdb/blob/ddc07b40fc699ab1caead6a04def25fc4e5526de/include/rocksdb/options.h#L560) (currently 1000).