### PR TITLE
link error fix

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -85,6 +85,7 @@ fn build_rocksdb() {
 
     if cfg!(windows) {
         link("rpcrt4", false);
+        link("Shlwapi", false);
         config.define("OS_WIN", Some("1"));
 
         // Remove POSIX-specific sources


### PR DESCRIPTION
fix link error on windows when run `cargo test`.
 [https://docs.microsoft.com/en-us/windows/desktop/api/shlwapi/nf-shlwapi-pathisrelativea](url)