### PR TITLE
Expose 'set_skip_stats_update_on_db_open' option

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1098,6 +1098,17 @@ impl Options {
             ffi::rocksdb_options_set_wal_dir(self.inner, p.as_ptr());
         }
     }
+
+    /// If true, then DB::Open() will not update the statistics used to optimize
+    /// compaction decision by loading table properties from many files.
+    /// Turning off this feature will improve DBOpen time especially in disk environment.
+    ///
+    /// Default: false
+    pub fn set_skip_stats_update_on_db_open(&mut self, skip: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_skip_stats_update_on_db_open(self.inner, skip as c_uchar);
+        }
+    }
 }
 
 impl Default for Options {


### PR DESCRIPTION
Following the suggestion from https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide#spinning-disks-usually-provide-much-lower-random-read-throughput-than-flash