### PR TITLE
Made the DBIterator new functions public - To support passing ReadOptions to iterator

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -433,7 +433,7 @@ impl Drop for DBRawIterator {
 }
 
 impl DBIterator {
-    fn new(db: &DB, readopts: &ReadOptions, mode: IteratorMode) -> DBIterator {
+    pub fn new(db: &DB, readopts: &ReadOptions, mode: IteratorMode) -> DBIterator {
         let mut rv = DBIterator {
             raw: DBRawIterator::new(db, readopts),
             direction: Direction::Forward, // blown away by set_mode()
@@ -443,7 +443,7 @@ impl DBIterator {
         rv
     }
 
-    fn new_cf(
+    pub fn new_cf(
         db: &DB,
         cf_handle: ColumnFamily,
         readopts: &ReadOptions,


### PR DESCRIPTION
Hi,
I want to use `DBIterator` with `set_iterate_upper_bound`, but no iterator function opens the possibility to give my own ReadOptions.

I think just making `DBIterator::new()` public is the simplest solution, although maybe it's better to add functions to DB that will support transforming it into an iterator and receiving Readoptions.

Thanks.