### PR TITLE
Bump bindgen up to 0.43

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -31,5 +31,5 @@ uuid = { version = "0.7", features = ["v4"] }
 [build-dependencies]
 cc = { version = "^1.0", features = ["parallel"] }
 make-cmd = "0.1"
-bindgen = "0.37"
+bindgen = "0.43"
 glob = "0.2.11"


### PR DESCRIPTION
I would like to build `rocksdb` with `mozjs`, but cannot
do this bacause of the version conflict.

Everything seems to work fine with the new version.