### PR TITLE
Adding license and commits-since release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 rust-rocksdb
 ============
 [![Build Status](https://travis-ci.org/rust-rocksdb/rust-rocksdb.svg?branch=master)](https://travis-ci.org/rust-rocksdb/rust-rocksdb)
-[![crates.io](http://meritbadge.herokuapp.com/rocksdb)](https://crates.io/crates/rocksdb)
+[![crates.io](https://meritbadge.herokuapp.com/rocksdb)](https://crates.io/crates/rocksdb)
 [![documentation](https://docs.rs/rocksdb/badge.svg)](https://docs.rs/rocksdb)
+[![license](https://img.shields.io/crates/l/rocksdb.svg)](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/LICENSE)
 [![Gitter chat](https://badges.gitter.im/rust-rocksdb/gitter.png)](https://gitter.im/rust-rocksdb/lobby)
+
+
+![GitHub commits (since latest release)](https://img.shields.io/github/commits-since/rust-rocksdb/rust-rocksdb/latest.svg)
 
 Feedback and pull requests welcome!  If a particular feature of RocksDB is 
 important to you, please let me know by opening an issue, and I'll 


### PR DESCRIPTION
Adding the license badge to make the license stand out a bit more and the "commits since latest release" badge to provided subtle reminder to maintainers of the amount of work not yet released.