### PR TITLE
Using generic types to specify column families when opening database...

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -679,7 +679,7 @@ impl DB {
         DB::open_cf_descriptors(opts, path, cfs)
     }
 
-    /// Open a database with the given database options and column family names/options.
+    /// Open a database with the given database options and column family descriptors.
     pub fn open_cf_descriptors<P, I>(
         opts: &Options,
         path: P,

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,6 @@ use std::collections::BTreeMap;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::fs;
-use std::iter;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::path::Path;
@@ -661,7 +660,7 @@ impl DB {
 
     /// Open the database with the specified options.
     pub fn open<P: AsRef<Path>>(opts: &Options, path: P) -> Result<DB, Error> {
-        DB::open_cf(opts, path, iter::empty::<&str>())
+        DB::open_cf(opts, path, None::<&str>)
     }
 
     /// Open a database with the given database options and column family names.

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,6 +22,7 @@ use std::collections::BTreeMap;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::fs;
+use std::iter;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::path::Path;
@@ -660,28 +661,37 @@ impl DB {
 
     /// Open the database with the specified options.
     pub fn open<P: AsRef<Path>>(opts: &Options, path: P) -> Result<DB, Error> {
-        DB::open_cf(opts, path, &[])
+        DB::open_cf(opts, path, iter::empty::<&str>())
     }
 
     /// Open a database with the given database options and column family names.
     ///
     /// Column families opened using this function will be created with default `Options`.
-    pub fn open_cf<P: AsRef<Path>>(opts: &Options, path: P, cfs: &[&str]) -> Result<DB, Error> {
-        let cfs_v = cfs
-            .to_vec()
-            .iter()
-            .map(|name| ColumnFamilyDescriptor::new(*name, Options::default()))
-            .collect();
+    pub fn open_cf<P, I, N>(opts: &Options, path: P, cfs: I) -> Result<DB, Error> 
+        where P: AsRef<Path>,
+              I: IntoIterator<Item = N>,
+              N: AsRef<str> {
 
-        DB::open_cf_descriptors(opts, path, cfs_v)
+        let cfs = cfs
+            .into_iter()
+            .map(|name| ColumnFamilyDescriptor::new(name.as_ref(), Options::default()));
+
+        DB::open_cf_descriptors(opts, path, cfs)
     }
 
     /// Open a database with the given database options and column family names/options.
-    pub fn open_cf_descriptors<P: AsRef<Path>>(
+    pub fn open_cf_descriptors<P, I>(
         opts: &Options,
         path: P,
-        cfs: Vec<ColumnFamilyDescriptor>,
-    ) -> Result<DB, Error> {
+        cfs: I,
+    ) -> Result<DB, Error> 
+        where P: AsRef<Path>,
+              I: IntoIterator<Item = ColumnFamilyDescriptor> {
+
+        let cfs: Vec<_> = cfs
+            .into_iter()
+            .collect();
+
         let path = path.as_ref();
         let cpath = match CString::new(path.to_string_lossy().as_bytes()) {
             Ok(c) => c,

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -100,12 +100,7 @@ fn test_can_open_db_with_results_of_list_cf() {
         let db = DB::open(&opts, &n).unwrap();
         let opts = Options::default();
 
-        match db.create_cf("cf1", &opts) {
-            Ok(_db) => println!("cf1 created successfully"),
-            Err(e) => {
-                panic!("could not create column family: {}", e);
-            }
-        }
+        assert!(db.create_cf("cf1", &opts).is_ok());
     }
 
     {

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -19,7 +19,7 @@ use rocksdb::{ColumnFamilyDescriptor, MergeOperands, Options, DB};
 use util::DBPath;
 
 #[test]
-pub fn test_column_family() {
+fn test_column_family() {
     let n = DBPath::new("_rust_rocksdb_cftest");
 
     // should be able to create column families
@@ -85,6 +85,35 @@ pub fn test_column_family() {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),
         }
+    }
+}
+
+#[test]
+fn test_can_open_db_with_results_of_list_cf() {
+    // Test scenario derived from GitHub issue #175 and 177
+
+    let n = DBPath::new("_rust_rocksdb_cftest_with_list_cf");
+
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, &n).unwrap();
+        let opts = Options::default();
+
+        match db.create_cf("cf1", &opts) {
+            Ok(_db) => println!("cf1 created successfully"),
+            Err(e) => {
+                panic!("could not create column family: {}", e);
+            }
+        }
+    }
+
+    {
+        let options = Options::default();
+        let cfs = DB::list_cf(&options, &n).unwrap();
+        let db = DB::open_cf(&options, &n, &cfs).unwrap();
+
+        assert!(db.cf_handle("cf1").is_some());
     }
 }
 
@@ -172,7 +201,7 @@ fn test_provided_merge(
 }
 
 #[test]
-pub fn test_column_family_with_options() {
+fn test_column_family_with_options() {
     let n = DBPath::new("_rust_rocksdb_cf_with_optionstest");
     {
         let mut cfopts = Options::default();


### PR DESCRIPTION
This change requires no changes to existing tests. Fixes #175 and fixes #177. 