### PR TITLE
Generic DB.create_cf and test for duplicate column families.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1027,8 +1027,8 @@ impl DB {
         self.get_pinned_cf_opt(cf, key, &ReadOptions::default())
     }
 
-    pub fn create_cf(&self, name: &str, opts: &Options) -> Result<ColumnFamily, Error> {
-        let cname = match CString::new(name.as_bytes()) {
+    pub fn create_cf<N: AsRef<str>>(&self, name: N, opts: &Options) -> Result<ColumnFamily, Error> {
+        let cname = match CString::new(name.as_ref().as_bytes()) {
             Ok(c) => c,
             Err(_) => {
                 return Err(Error::new(
@@ -1048,7 +1048,7 @@ impl DB {
             self.cfs
                 .write()
                 .map_err(|e| Error::new(e.to_string()))?
-                .insert(name.to_string(), cf_handle);
+                .insert(name.as_ref().to_string(), cf_handle);
 
             ColumnFamily {
                 inner: cf_handle,

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -238,3 +238,20 @@ fn test_column_family_with_options() {
         }
     }
 }
+
+#[test]
+fn test_create_duplicate_column_family() {
+    let n = DBPath::new("_rust_rocksdb_create_duplicate_column_family");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        let db = match DB::open_cf(&opts, &n, &["cf1"]) {
+            Ok(d) => d,
+            Err(e) => panic!("failed to create new column family: {}", e),
+        };
+
+        assert!(db.create_cf("cf1", &opts).is_err());
+    }
+}


### PR DESCRIPTION
Fixes #36.