### PR TITLE
Remove allocations from SliceTransform

### DIFF
--- a/tests/test_slice_transform.rs
+++ b/tests/test_slice_transform.rs
@@ -13,8 +13,8 @@ pub fn test_slice_transform() {
         let b1: Box<[u8]> = key(b"bbb1");
         let b2: Box<[u8]> = key(b"bbb2");
 
-        fn first_three(k: &[u8]) -> Vec<u8> {
-            k.iter().take(3).cloned().collect()
+        fn first_three<'a>(k: &'a [u8]) -> &'a [u8] {
+            &k[..3]
         }
 
         let prefix_extractor = SliceTransform::create("first_three", first_three, None);


### PR DESCRIPTION
This adopts [pingcap/rust-rocksdb](https://github.com/pingcap/rust-rocksdb)'s SliceTransform [approach](https://github.com/pingcap/rust-rocksdb/blob/master/src/slice_transform.rs), which changes the signature of `transform_fn` from `&[u8] -> Vec<u8>` to `&'a [u8] -> &'a [u8]` while removing the manual `malloc` call we're currently doing in `transform_callback`.

This significantly reduces memory usage, to the point where I wonder if this might actually be a memory leak if rocksdb isn't actually freeing the prefixes that we allocate in `transform_callback`. I might be wrong about this though—see the attached heap dump below.

### Breaking change
The main use case for slice transforms is to create prefixes from existing keys, which you don't really need allocations for. However, in theory, the existing API could be used to create prefixes from completely different keys than what's passed in:

```rust
fn transform(k: &[u8]) -> Vec<u8> {
    "aa".as_bytes().to_vec()
}
```

This wouldn't be possible anymore with the API proposed in this PR.

### Alternative API
PingCAP implements slice transforms [as a trait](https://github.com/pingcap/rust-rocksdb/blob/master/src/slice_transform.rs#L19-L38) where the transform function has a mutable receiver. This is a more flexible API in my opinion, but it would make the upgrade lift even more significant than what this PR already proposes. What do you think?

### Heap dump
Test program: https://gist.github.com/ekmartin/e96275f09874a13a578faf0fbd2d0f6d
Mastiff dump with master: https://gist.github.com/ekmartin/41f3c4eb56ccfb3caa26191605d8097b
Mastiff dump with this branch: https://gist.github.com/ekmartin/e0f47e44cb9d0142e09a87f8de8e949b