### PR TITLE
Added raw_iterator_opt method to DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1162,6 +1162,10 @@ impl DB {
         DBRawIterator::new(self, &opts)
     }
 
+    pub fn raw_iterator_opt(&self, opts: ReadOptions) -> DBRawIterator {
+        DBRawIterator::new(self, &opts)
+    }
+
     pub fn raw_iterator_cf(&self, cf_handle: ColumnFamily) -> Result<DBRawIterator, Error> {
         let opts = ReadOptions::default();
         DBRawIterator::new_cf(self, cf_handle, &opts)


### PR DESCRIPTION
Now we can use the DBRawIterator with customized opts directly:

```
...
        let mut opts = ReadOptions::default();
        opts.set_prefix_same_as_start(true);
        let mut iter: DBRawIterator = db.raw_iterator_opt(opts);
        iter.seek(b"prefix");
...
```