### PR TITLE
Update DB::compact_range_cf() arguments to be consistent with other methods

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1362,8 +1362,16 @@ impl DB {
         }
     }
 
-    pub fn compact_range_cf(&self, cf: ColumnFamily, start: Option<&[u8]>, end: Option<&[u8]>) {
+    pub fn compact_range_cf<S: AsRef<[u8]>, E: AsRef<[u8]>>(
+        &self,
+        cf: ColumnFamily,
+        start: Option<S>,
+        end: Option<E>,
+    ) {
         unsafe {
+            let start = start.as_ref().map(|s| s.as_ref());
+            let end = end.as_ref().map(|e| e.as_ref());
+
             ffi::rocksdb_compact_range_cf(
                 self.inner,
                 cf.inner,


### PR DESCRIPTION
Following https://github.com/rust-rocksdb/rust-rocksdb/commit/21b9a9e98aa5f2d6d3a04cab2cc2dedfa3011fb6.