### PR TITLE
add comment for ReadOptions.set_iterate_upper_bound method.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1768,9 +1768,10 @@ impl ReadOptions {
         }
     }
 
+    /// set_iterate_upper_bound sets the upper bound for an iterator, and the upper bound itself
+    /// is not included on the iteration result.
     pub fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
         let key = key.as_ref();
-
         unsafe {
             ffi::rocksdb_readoptions_set_iterate_upper_bound(
                 self.inner,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1768,8 +1768,7 @@ impl ReadOptions {
         }
     }
 
-    /// Set the upper bound for an iterator, and the upper bound itself
-    /// is not included on the iteration result.
+    /// Set the upper bound for an iterator, and the upper bound itself is not included on the iteration result.
     pub fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
         let key = key.as_ref();
         unsafe {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1104,7 +1104,7 @@ impl DB {
         DBIterator::new_cf(self, cf_handle, &readopts, mode)
     }
 
-    /// Opens an interator with `set_total_order_seek` enabled.
+    /// Opens an iterator with `set_total_order_seek` enabled.
     /// This must be used to iterate across prefixes when `set_memtable_factory` has been called
     /// with a Hash-based implementation.
     pub fn full_iterator(&self, mode: IteratorMode) -> DBIterator {
@@ -1768,7 +1768,7 @@ impl ReadOptions {
         }
     }
 
-    /// set_iterate_upper_bound sets the upper bound for an iterator, and the upper bound itself
+    /// Set the upper bound for an iterator, and the upper bound itself
     /// is not included on the iteration result.
     pub fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
         let key = key.as_ref();


### PR DESCRIPTION
the method `ReadOptions.set_iterate_upper_bound` method seems confusing, because the upper_bound is not returned when doing iteration.  some comment are added for this method.