### PR TITLE
Add lifetimes for `DBIterator` return types 

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -559,7 +559,7 @@ impl<'a> Snapshot<'a> {
         }
     }
 
-    pub fn iterator(&self, mode: IteratorMode) -> DBIterator {
+    pub fn iterator(&self, mode: IteratorMode) -> DBIterator<'a> {
         let readopts = ReadOptions::default();
         self.iterator_opt(mode, readopts)
     }
@@ -573,7 +573,7 @@ impl<'a> Snapshot<'a> {
         self.iterator_cf_opt(cf_handle, readopts, mode)
     }
 
-    pub fn iterator_opt(&self, mode: IteratorMode, mut readopts: ReadOptions) -> DBIterator {
+    pub fn iterator_opt(&self, mode: IteratorMode, mut readopts: ReadOptions) -> DBIterator<'a> {
         readopts.set_snapshot(self);
         DBIterator::new(self.db, &readopts, mode)
     }
@@ -1084,12 +1084,12 @@ impl DB {
         })
     }
 
-    pub fn iterator(&self, mode: IteratorMode) -> DBIterator {
+    pub fn iterator<'a, 'b: 'a>(&'a self, mode: IteratorMode) -> DBIterator<'b> {
         let readopts = ReadOptions::default();
         self.iterator_opt(mode, &readopts)
     }
 
-    pub fn iterator_opt(&self, mode: IteratorMode, readopts: &ReadOptions) -> DBIterator {
+    pub fn iterator_opt<'a, 'b: 'a>(&'a self, mode: IteratorMode, readopts: &ReadOptions) -> DBIterator<'b> {
         DBIterator::new(self, &readopts, mode)
     }
 
@@ -1107,13 +1107,13 @@ impl DB {
     /// Opens an iterator with `set_total_order_seek` enabled.
     /// This must be used to iterate across prefixes when `set_memtable_factory` has been called
     /// with a Hash-based implementation.
-    pub fn full_iterator(&self, mode: IteratorMode) -> DBIterator {
+    pub fn full_iterator<'a, 'b: 'a>(&'a self, mode: IteratorMode) -> DBIterator<'b> {
         let mut opts = ReadOptions::default();
         opts.set_total_order_seek(true);
         DBIterator::new(self, &opts, mode)
     }
 
-    pub fn prefix_iterator<P: AsRef<[u8]>>(&self, prefix: P) -> DBIterator {
+    pub fn prefix_iterator<'a, 'b: 'a, P: AsRef<[u8]>>(&'a self, prefix: P) -> DBIterator<'b> {
         let mut opts = ReadOptions::default();
         opts.set_prefix_same_as_start(true);
         DBIterator::new(

--- a/src/db.rs
+++ b/src/db.rs
@@ -1089,7 +1089,11 @@ impl DB {
         self.iterator_opt(mode, &readopts)
     }
 
-    pub fn iterator_opt<'a, 'b: 'a>(&'a self, mode: IteratorMode, readopts: &ReadOptions) -> DBIterator<'b> {
+    pub fn iterator_opt<'a, 'b: 'a>(
+        &'a self,
+        mode: IteratorMode,
+        readopts: &ReadOptions,
+    ) -> DBIterator<'b> {
         DBIterator::new(self, &readopts, mode)
     }
 

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -299,3 +299,21 @@ fn test_full_iterator() {
     let opts = Options::default();
     assert!(DB::destroy(&opts, path).is_ok());
 }
+
+fn custom_iter(db: &DB) -> impl Iterator<Item = usize> {
+    db.iterator(IteratorMode::Start)
+        .map(|(_, db_value)| db_value.len())
+}
+
+#[test]
+fn test_custom_iterator() {
+    let path = DBPath::new("_rust_rocksdb_customiterator_test");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, &path).unwrap();
+        let _data = custom_iter(&db).collect::<Vec<usize>>();
+    }
+    let opts = Options::default();
+    assert!(DB::destroy(&opts, path).is_ok());
+}


### PR DESCRIPTION
Without them, the added simple test case doesn't compile.