### PR TITLE
Add `rocksdb_flush` method on DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,7 +15,7 @@
 
 use ffi;
 use ffi_util::opt_bytes_to_ptr;
-use {ColumnFamily, ColumnFamilyDescriptor, Error, Options, WriteOptions, DB};
+use {ColumnFamily, ColumnFamilyDescriptor, Error, Options, FlushOptions, WriteOptions, DB};
 
 use libc::{self, c_char, c_int, c_uchar, c_void, size_t};
 use std::collections::BTreeMap;
@@ -834,6 +834,17 @@ impl DB {
 
     pub fn path(&self) -> &Path {
         &self.path.as_path()
+    }
+
+    pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_flush(self.inner, flushopts.inner,));
+        }
+        Ok(())
+    }
+
+    pub fn flush(&self) -> Result<(), Error> {
+        self.flush_opt(&FlushOptions::default())
     }
 
     pub fn write_opt(&self, batch: WriteBatch, writeopts: &WriteOptions) -> Result<(), Error> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -836,6 +836,7 @@ impl DB {
         &self.path.as_path()
     }
 
+    /// Flush database memtable to SST files on disk (with options).
     pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_flush(self.inner, flushopts.inner,));
@@ -843,6 +844,7 @@ impl DB {
         Ok(())
     }
 
+    /// Flush database memtable to SST files on disk.
     pub fn flush(&self) -> Result<(), Error> {
         self.flush_opt(&FlushOptions::default())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -15,7 +15,7 @@
 
 use ffi;
 use ffi_util::opt_bytes_to_ptr;
-use {ColumnFamily, ColumnFamilyDescriptor, Error, Options, FlushOptions, WriteOptions, DB};
+use {ColumnFamily, ColumnFamilyDescriptor, Error, FlushOptions, Options, WriteOptions, DB};
 
 use libc::{self, c_char, c_int, c_uchar, c_void, size_t};
 use std::collections::BTreeMap;

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -27,7 +27,7 @@ use merge_operator::{
 use slice_transform::SliceTransform;
 use {
     BlockBasedIndexType, BlockBasedOptions, DBCompactionStyle, DBCompressionType, DBRecoveryMode,
-    MemtableFactory, Options, PlainTableFactoryOptions, WriteOptions,
+    MemtableFactory, Options, PlainTableFactoryOptions, FlushOptions, WriteOptions,
 };
 
 pub fn new_cache(capacity: size_t) -> *mut ffi::rocksdb_cache_t {
@@ -48,6 +48,14 @@ impl Drop for BlockBasedOptions {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_block_based_options_destroy(self.inner);
+        }
+    }
+}
+
+impl Drop for FlushOptions {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_flushoptions_destroy(self.inner);
         }
     }
 }
@@ -1205,6 +1213,28 @@ impl Default for Options {
             }
             Options { inner: opts }
         }
+    }
+}
+
+impl FlushOptions {
+    pub fn new() -> FlushOptions {
+        FlushOptions::default()
+    }
+
+    pub fn set_wait(&mut self, wait: bool) {
+        unsafe {
+            ffi::rocksdb_flushoptions_set_wait(self.inner, wait as c_uchar);
+        }
+    }
+}
+
+impl Default for FlushOptions {
+    fn default() -> FlushOptions {
+        let flush_opts = unsafe { ffi::rocksdb_flushoptions_create() };
+        if flush_opts.is_null() {
+            panic!("Could not create RocksDB flush options");
+        }
+        FlushOptions { inner: flush_opts }
     }
 }
 

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -27,7 +27,7 @@ use merge_operator::{
 use slice_transform::SliceTransform;
 use {
     BlockBasedIndexType, BlockBasedOptions, DBCompactionStyle, DBCompressionType, DBRecoveryMode,
-    MemtableFactory, Options, PlainTableFactoryOptions, FlushOptions, WriteOptions,
+    FlushOptions, MemtableFactory, Options, PlainTableFactoryOptions, WriteOptions,
 };
 
 pub fn new_cache(capacity: size_t) -> *mut ffi::rocksdb_cache_t {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1221,6 +1221,18 @@ impl FlushOptions {
         FlushOptions::default()
     }
 
+    /// Waits until the flush is done.
+    ///
+    /// Default: true
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rocksdb::FlushOptions;
+    ///
+    /// let mut options = FlushOptions::default();
+    /// options.set_wait(false);
+    /// ```
     pub fn set_wait(&mut self, wait: bool) {
         unsafe {
             ffi::rocksdb_flushoptions_set_wait(self.inner, wait as c_uchar);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,30 @@ pub struct Options {
     inner: *mut ffi::rocksdb_options_t,
 }
 
+/// Optionally wait for the memtable flush to be performed.
+///
+/// # Examples
+///
+/// Manually flushing the memtable:
+///
+/// ```
+/// use rocksdb::{DB, Options, FlushOptions};
+///
+/// let path = "_path_for_rocksdb_storageY";
+/// {
+///     let db = DB::open_default(path).unwrap();
+///
+///     let mut flush_options = FlushOptions::default();
+///     flush_options.set_wait(true);
+///
+///     db.flush_opt(&flush_options);
+/// }
+/// let _ = DB::destroy(&Options::default(), path);
+/// ```
+pub struct FlushOptions {
+    inner: *mut ffi::rocksdb_flushoptions_t,
+}
+
 /// Optionally disable WAL or sync for this write.
 ///
 /// # Examples


### PR DESCRIPTION
As `rust-rocksdb` already had the `disable_wal` method on `WriteOptions` (see: https://docs.rs/rocksdb/0.12.1/rocksdb/struct.WriteOptions.html#method.disable_wal), it makes sense to implement the `DB::flush()` method that lets the user perform a manual memtable flush to SST files.

This is useful when performing all writes to RocksDB in `disable_wal=true` mode; in such case upon process shutdown (eg. SIGTERM) memtables should be manually flushed to commit changes to disk and avoid data loss.

This `disable_wal` + manual `flush` pattern can be useful on busy servers using RocksDB on SSDs as to minimize SSD write wear.