### PR TITLE
Add raw_iterator_cf_opt to the DB API

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -588,21 +588,25 @@ impl<'a> Snapshot<'a> {
         DBIterator::new_cf(self.db, cf_handle, &readopts, mode)
     }
 
+    /// Opens a raw iterator over the data in this snapshot, using the default read options.
     pub fn raw_iterator(&self) -> DBRawIterator {
         let readopts = ReadOptions::default();
         self.raw_iterator_opt(readopts)
     }
 
+    /// Opens a raw iterator over the data in this snapshot under the given column family, using the default read options.
     pub fn raw_iterator_cf(&self, cf_handle: ColumnFamily) -> Result<DBRawIterator, Error> {
         let readopts = ReadOptions::default();
         self.raw_iterator_cf_opt(cf_handle, readopts)
     }
 
+    /// Opens a raw iterator over the data in this snapshot, using the given read options.
     pub fn raw_iterator_opt(&self, mut readopts: ReadOptions) -> DBRawIterator {
         readopts.set_snapshot(self);
         DBRawIterator::new(self.db, &readopts)
     }
 
+    /// Opens a raw iterator over the data in this snapshot under the given column family, using the given read options.
     pub fn raw_iterator_cf_opt(
         &self,
         cf_handle: ColumnFamily,
@@ -1157,16 +1161,24 @@ impl DB {
         )
     }
 
+    /// Opens a raw iterator over the database, using the default read options
     pub fn raw_iterator(&self) -> DBRawIterator {
         let opts = ReadOptions::default();
         DBRawIterator::new(self, &opts)
     }
 
+    /// Opens a raw iterator over the given column family, using the default read options
     pub fn raw_iterator_cf(&self, cf_handle: ColumnFamily) -> Result<DBRawIterator, Error> {
         let opts = ReadOptions::default();
         DBRawIterator::new_cf(self, cf_handle, &opts)
     }
 
+    /// Opens a raw iterator over the database, using the given read options
+    pub fn raw_iterator_opt(&self, readopts: &ReadOptions) -> DBRawIterator {
+        DBRawIterator::new(self, readopts)
+    }
+
+    /// Opens a raw iterator over the given column family, using the given read options
     pub fn raw_iterator_cf_opt(
         &self,
         cf_handle: ColumnFamily,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1167,6 +1167,14 @@ impl DB {
         DBRawIterator::new_cf(self, cf_handle, &opts)
     }
 
+    pub fn raw_iterator_cf_opt(
+        &self,
+        cf_handle: ColumnFamily,
+        readopts: &ReadOptions,
+    ) -> Result<DBRawIterator, Error> {
+        DBRawIterator::new_cf(self, cf_handle, readopts)
+    }
+
     pub fn snapshot(&self) -> Snapshot {
         Snapshot::new(self)
     }


### PR DESCRIPTION
The underlying functionality already existed, but it wasn't exposed to
the top-level API.

This is essentially the same as #288 but exposes the column family iterator instead of the default one