### PR TITLE
Updated librocksdb dependencies

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -30,5 +30,5 @@ uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
 cc = { version = "^1.0", features = ["parallel"] }
-bindgen = "0.47"
-glob = "0.2.11"
+bindgen = "0.49"
+glob = "0.3"


### PR DESCRIPTION
Hi,
In my app I must use the latest `rust-bindgen` but it conflicts with yours.
so I updated all of the outdated dependencies, what do you think?

the error:
```
    Updating crates.io index
error: failed to select a version for `clang-sys`.
    ... required by package `bindgen v0.47.0`
    ... which is depended on by `librocksdb-sys v5.18.3`
    ... which is depended on by `rocksdb v0.12.2`
    ... which is depended on by `enigma-core-app v0.1.3 (enigma-core/app)`
versions that meet the requirements `^0.27.0` are: 0.27.0

the package `clang-sys` links to the native library `clang`, but it conflicts with a previous package which links to `clang` as well:
package `clang-sys v0.28.0`
    ... which is depended on by `bindgen v0.49.2`
    ... which is depended on by `enigma-core-app v0.1.3 (enigma-core/app)`

failed to select a version for `clang-sys` which could resolve this conflict
```