### PR TITLE
Make the set_iterate_upper_bound ReadOptions method unsafe

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1781,8 +1781,15 @@ impl ReadOptions {
         }
     }
 
-    /// Set the upper bound for an iterator, and the upper bound itself is not included on the iteration result.
-    pub fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
+    /// Set the upper bound for an iterator.
+    /// The upper bound itself is not included on the iteration result.
+    ///
+    /// # Safety
+    ///
+    /// This function will store a clone of key and will give a raw pointer of it to the
+    /// underlying C++ API, therefore, when given to any other [`DB`] method you must ensure
+    /// that this [`ReadOptions`] value does not leave the scope too early (e.g. `DB::iterator_cf_opt`).
+    pub unsafe fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
         let key = key.as_ref();
         unsafe {
             ffi::rocksdb_readoptions_set_iterate_upper_bound(


### PR DESCRIPTION
Currently the internal code of this function take a pointer to something that can live the scope too early producing a segfault.

https://github.com/hjiayz/rust-rocksdb/blob/7ba1f9d64abdc96c81b1415eb1685470f96e2eac/src/db_options.rs#L82-L90

Here is a simple example of what can happen, "my_key" does not live long enough, it is stored on the stack and the pointer used by `ReadOptions` is dropped at the end of the scope but not the `DBIterator`. Therefore the `DBIterator` segfault when it tries to access to the internal pointer of the "upper_bound" key inside of the now dead `ReadOptions`.

```rust
fn produce_an_iterator(db: &DB) -> DBIterator {
    let my_key = "my-super-key";
    let options = ReadOptions::default().set_iterate_upper_bound(my_key);
    db.iterator_opt(&options).unwrap()
}
```

I would have loved to change the `DBIterator` to own the "upper_bound" but I do not know what you think about that.

Another way to fix this bug could be to make the `DBIterator` to be bounded by the `&'a ReadOptions` reference lifetime parameter but it will make the API unusable, sadly...