### PR TITLE
Implement Send and Sync for Snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.12.3
+## Unreleased
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.3
+
+### Changes
+
+* Added `Sync` and `Send` implementations to `Snapshot` (pavel-mukhanov)
+
 ## 0.12.2 (2019-05-03)
 
 ### Changes

--- a/src/db.rs
+++ b/src/db.rs
@@ -104,6 +104,9 @@ pub struct Snapshot<'a> {
     inner: *const ffi::rocksdb_snapshot_t,
 }
 
+unsafe impl<'a> Send for Snapshot<'a> {}
+unsafe impl<'a> Sync for Snapshot<'a> {}
+
 /// An iterator over a database or column family, with specifiable
 /// ranges and direction.
 ///

--- a/src/db.rs
+++ b/src/db.rs
@@ -104,6 +104,8 @@ pub struct Snapshot<'a> {
     inner: *const ffi::rocksdb_snapshot_t,
 }
 
+/// `Send` and `Sync` implementations for `Snapshot` are safe, because `Snapshot` is
+/// immutable and can be safely shared between threads.
 unsafe impl<'a> Send for Snapshot<'a> {}
 unsafe impl<'a> Sync for Snapshot<'a> {}
 

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -22,8 +22,8 @@ mod util;
 use libc::size_t;
 
 use rocksdb::{DBVector, Error, IteratorMode, Options, WriteBatch, DB};
-use util::DBPath;
 use std::thread;
+use util::DBPath;
 
 #[test]
 fn test_db_vector() {
@@ -180,15 +180,25 @@ fn sync_snapshot_test() {
         // Unsafe here is safe, because `handler.join()` is called at the end of the
         // method to ensure that snapshot will not outlive database.
         let handler_1 = unsafe {
-            thread::Builder::new().spawn_unchecked(|| {
-                assert_eq!(snapshot.get(b"k1").unwrap().unwrap().to_utf8().unwrap(), "v1");
-            }).unwrap()
+            thread::Builder::new()
+                .spawn_unchecked(|| {
+                    assert_eq!(
+                        snapshot.get(b"k1").unwrap().unwrap().to_utf8().unwrap(),
+                        "v1"
+                    );
+                })
+                .unwrap()
         };
 
         let handler_2 = unsafe {
-            thread::Builder::new().spawn_unchecked(|| {
-                assert_eq!(snapshot.get(b"k2").unwrap().unwrap().to_utf8().unwrap(), "v2");
-            }).unwrap()
+            thread::Builder::new()
+                .spawn_unchecked(|| {
+                    assert_eq!(
+                        snapshot.get(b"k2").unwrap().unwrap().to_utf8().unwrap(),
+                        "v2"
+                    );
+                })
+                .unwrap()
         };
 
         handler_1.join().unwrap();


### PR DESCRIPTION
As far it is safe to share `Snapshot` between threads I've implemented `Send` and `Sync` for it.

[Snapshot documentations from sources.](https://github.com/facebook/rocksdb/blob/189f0c27aaecdf17ae7fc1f826a423a28b77984f/include/rocksdb/snapshot.h#L15)