### PR TITLE
Build RocksDB with support for unicode filenames on Windows

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -123,6 +123,7 @@ fn build_rocksdb() {
         link("rpcrt4", false);
         link("shlwapi", false);
         config.define("OS_WIN", Some("1"));
+        config.define("ROCKSDB_WINDOWS_UTF8_FILENAMES", Some("1"));
 
         // Remove POSIX-specific sources
         lib_sources = lib_sources


### PR DESCRIPTION
This causes RocksDB to wrap all fs operations using the wide filesystem apis:
<https://github.com/facebook/rocksdb/blob/master/port/win/port_win.h#L345>

Fixes #85 - even though it's already closed.

This problem was originally [punted by RocksDB developers](https://github.com/facebook/rocksdb/issues/3408), but a solution that doesn't require a custom environment was merged in [October last year](https://github.com/facebook/rocksdb/pull/4469).