### PR TITLE
Disable trait derivation for librocksdb-sys (fixes #335)

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -33,6 +33,7 @@ fn fail_on_empty_directory(name: &str) {
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
         .header("rocksdb/include/rocksdb/c.h")
+        .derive_debug(false)
         .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
         .generate()


### PR DESCRIPTION
## Rationale

This allows this crate to be used on the beta channel.

## Drawbacks

Generated librocksdb-sys structs no longer implement `Debug`, might have unintented consequences unknown to me.

## Alternatives

Feature-gate, or use cfg!.