### PR TITLE
Conditionally define bzip2 error callback function

### DIFF
--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -22,6 +22,7 @@ use libc::c_int;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+#[cfg(feature = "bzip2")]
 #[no_mangle]
 pub fn bz_internal_error(errcode: c_int) {
     panic!("bz internal error: {}", errcode);


### PR DESCRIPTION
Hi, this is my first, quick and one-liner pull request. Please let me know if anything isn't in good shape!

Currently, `bz_internal_error` is unconditionally and globally defined, which conflicts with other crates in some build situation. So, make it conditional only if needed.

As a background, #209 introduced compile-time conditional bzip2 support as one of other various compressions (ref: https://github.com/rust-rocksdb/rust-rocksdb/pull/209/files#diff-04c6e90faac2675aa89e2176d2eec7d8R17).

Mostly, the newly-added code is covered under respective `feature`s. However, `bz_internal_error` is not (ref: https://github.com/rust-rocksdb/rust-rocksdb/pull/209/files#diff-1da21bb01d3b5631d6399c8da32d163aR26). Obviously, `bz_internal_error` is needed only for the case of `feature = "bzip2"`.