### PR TITLE
Avoid copy in DBRawIterator::{key, value}

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2017,6 +2017,7 @@ unsafe impl Send for ReadOptions {}
 
 // Sync is similarly safe for many types because they do not expose interior mutability, and their
 // use within the rocksdb library is generally behind a const reference
+unsafe impl<'a> Sync for DBRawIterator<'a> {}
 unsafe impl Sync for ReadOptions {}
 
 /// Vector of bytes stored in the database.

--- a/tests/test_raw_iterator.rs
+++ b/tests/test_raw_iterator.rs
@@ -32,14 +32,14 @@ pub fn test_forwards_iteration() {
         iter.seek_to_first();
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k1".to_vec()));
-        assert_eq!(iter.value(), Some(b"v1".to_vec()));
+        assert_eq!(iter.key(), Some(b"k1".as_ref()));
+        assert_eq!(iter.value(), Some(b"v1".as_ref()));
 
         iter.next();
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k2".to_vec()));
-        assert_eq!(iter.value(), Some(b"v2".to_vec()));
+        assert_eq!(iter.key(), Some(b"k2".as_ref()));
+        assert_eq!(iter.value(), Some(b"v2".as_ref()));
 
         iter.next(); // k3
         iter.next(); // k4
@@ -65,14 +65,14 @@ pub fn test_seek_last() {
         iter.seek_to_last();
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k4".to_vec()));
-        assert_eq!(iter.value(), Some(b"v4".to_vec()));
+        assert_eq!(iter.key(), Some(b"k4".as_ref()));
+        assert_eq!(iter.value(), Some(b"v4".as_ref()));
 
         iter.prev();
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k3".to_vec()));
-        assert_eq!(iter.value(), Some(b"v3".to_vec()));
+        assert_eq!(iter.key(), Some(b"k3".as_ref()));
+        assert_eq!(iter.value(), Some(b"v3".as_ref()));
 
         iter.prev(); // k2
         iter.prev(); // k1
@@ -97,15 +97,15 @@ pub fn test_seek() {
         iter.seek(b"k2");
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k2".to_vec()));
-        assert_eq!(iter.value(), Some(b"v2".to_vec()));
+        assert_eq!(iter.key(), Some(b"k2".as_ref()));
+        assert_eq!(iter.value(), Some(b"v2".as_ref()));
 
         // Check it gets the next key when the key doesn't exist
         iter.seek(b"k3");
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k4".to_vec()));
-        assert_eq!(iter.value(), Some(b"v4".to_vec()));
+        assert_eq!(iter.key(), Some(b"k4".as_ref()));
+        assert_eq!(iter.value(), Some(b"v4".as_ref()));
     }
 }
 
@@ -122,8 +122,8 @@ pub fn test_seek_to_nonexistant() {
         iter.seek(b"k2");
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k3".to_vec()));
-        assert_eq!(iter.value(), Some(b"v3".to_vec()));
+        assert_eq!(iter.key(), Some(b"k3".as_ref()));
+        assert_eq!(iter.value(), Some(b"v3".as_ref()));
     }
 }
 
@@ -140,14 +140,14 @@ pub fn test_seek_for_prev() {
         iter.seek(b"k2");
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k2".to_vec()));
-        assert_eq!(iter.value(), Some(b"v2".to_vec()));
+        assert_eq!(iter.key(), Some(b"k2".as_ref()));
+        assert_eq!(iter.value(), Some(b"v2".as_ref()));
 
         // Check it gets the previous key when the key doesn't exist
         iter.seek_for_prev(b"k3");
 
         assert_eq!(iter.valid(), true);
-        assert_eq!(iter.key(), Some(b"k2".to_vec()));
-        assert_eq!(iter.value(), Some(b"v2".to_vec()));
+        assert_eq!(iter.key(), Some(b"k2".as_ref()));
+        assert_eq!(iter.value(), Some(b"v2".as_ref()));
     }
 }


### PR DESCRIPTION
Thanks to Rust's lifetime and borrow checker, it's completely safe to access internal buffer without copying, as any seek operation will need to take `&mut self`.

This PR therefore removes the copying `key` and `value` functions, and replace them with the originally unsafe `key_inner` and `value_inner`.