### PR TITLE
feat: simplify conversion on iterator item

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -609,8 +609,8 @@ impl<'a> Iterator for DBIterator<'a> {
         if self.raw.valid() {
             // .key() and .value() only ever return None if valid == false, which we've just cheked
             Some((
-                self.raw.key().unwrap().to_vec().into_boxed_slice(),
-                self.raw.value().unwrap().to_vec().into_boxed_slice(),
+                Box::from(self.raw.key().unwrap()),
+                Box::from(self.raw.value().unwrap()),
             ))
         } else {
             None


### PR DESCRIPTION
There is [impl<'_, T> From<&'_ [T]> for Box<[T]> where T: Copy](https://doc.rust-lang.org/nightly/std/boxed/struct.Box.html#impl-From%3C%26%27_%20%5BT%5D%3E), so the following work:
```rust
let slice: &[u8] = &[104, 101, 108, 108, 111];
let boxed_slice: Box<[u8]> = Box::from(slice);
```
Converting into a `Vec` makes no sense, indirect.