### PR TITLE
Improve ffi_try macro to make trailing comma optional

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -51,7 +51,7 @@ impl BackupEngine {
         };
 
         let be: *mut ffi::rocksdb_backup_engine_t;
-        unsafe { be = ffi_try!(ffi::rocksdb_backup_engine_open(opts.inner, cpath.as_ptr(),)) }
+        unsafe { be = ffi_try!(ffi::rocksdb_backup_engine_open(opts.inner, cpath.as_ptr())) }
 
         if be.is_null() {
             return Err(Error::new("Could not initialize backup engine.".to_owned()));

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -38,7 +38,7 @@ impl Checkpoint {
     pub fn new(db: &DB) -> Result<Checkpoint, Error> {
         let checkpoint: *mut ffi::rocksdb_checkpoint_t;
 
-        unsafe { checkpoint = ffi_try!(ffi::rocksdb_checkpoint_object_create(db.inner,)) };
+        unsafe { checkpoint = ffi_try!(ffi::rocksdb_checkpoint_object_create(db.inner)) };
 
         if checkpoint.is_null() {
             return Err(Error::new("Could not create checkpoint object.".to_owned()));

--- a/src/db.rs
+++ b/src/db.rs
@@ -192,7 +192,7 @@ impl DBWALIterator {
     /// called.
     pub fn status(&self) -> Result<(), Error> {
         unsafe {
-            ffi_try!(ffi::rocksdb_wal_iter_status(self.inner,));
+            ffi_try!(ffi::rocksdb_wal_iter_status(self.inner));
         }
         Ok(())
     }
@@ -314,7 +314,7 @@ impl<'a> DBRawIterator<'a> {
     /// Performing a seek will discard the current status.
     pub fn status(&self) -> Result<(), Error> {
         unsafe {
-            ffi_try!(ffi::rocksdb_iter_get_error(self.inner,));
+            ffi_try!(ffi::rocksdb_iter_get_error(self.inner));
         }
         Ok(())
     }
@@ -806,7 +806,7 @@ impl DB {
 
         if cfs.is_empty() {
             unsafe {
-                db = ffi_try!(ffi::rocksdb_open(opts.inner, cpath.as_ptr() as *const _,));
+                db = ffi_try!(ffi::rocksdb_open(opts.inner, cpath.as_ptr() as *const _));
             }
         } else {
             let mut cfs_v = cfs;
@@ -894,7 +894,7 @@ impl DB {
     pub fn destroy<P: AsRef<Path>>(opts: &Options, path: P) -> Result<(), Error> {
         let cpath = to_cpath(path)?;
         unsafe {
-            ffi_try!(ffi::rocksdb_destroy_db(opts.inner, cpath.as_ptr(),));
+            ffi_try!(ffi::rocksdb_destroy_db(opts.inner, cpath.as_ptr()));
         }
         Ok(())
     }
@@ -902,7 +902,7 @@ impl DB {
     pub fn repair<P: AsRef<Path>>(opts: &Options, path: P) -> Result<(), Error> {
         let cpath = to_cpath(path)?;
         unsafe {
-            ffi_try!(ffi::rocksdb_repair_db(opts.inner, cpath.as_ptr(),));
+            ffi_try!(ffi::rocksdb_repair_db(opts.inner, cpath.as_ptr()));
         }
         Ok(())
     }
@@ -914,7 +914,7 @@ impl DB {
     /// Flush database memtable to SST files on disk (with options).
     pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
         unsafe {
-            ffi_try!(ffi::rocksdb_flush(self.inner, flushopts.inner,));
+            ffi_try!(ffi::rocksdb_flush(self.inner, flushopts.inner));
         }
         Ok(())
     }
@@ -926,7 +926,7 @@ impl DB {
 
     pub fn write_opt(&self, batch: WriteBatch, writeopts: &WriteOptions) -> Result<(), Error> {
         unsafe {
-            ffi_try!(ffi::rocksdb_write(self.inner, writeopts.inner, batch.inner,));
+            ffi_try!(ffi::rocksdb_write(self.inner, writeopts.inner, batch.inner));
         }
         Ok(())
     }
@@ -1100,7 +1100,7 @@ impl DB {
     pub fn drop_cf(&mut self, name: &str) -> Result<(), Error> {
         if let Some(cf) = self.cfs.remove(name) {
             unsafe {
-                ffi_try!(ffi::rocksdb_drop_column_family(self.inner, cf.inner,));
+                ffi_try!(ffi::rocksdb_drop_column_family(self.inner, cf.inner));
             }
             Ok(())
         } else {
@@ -1601,7 +1601,7 @@ impl DB {
             // for creating and destroying it; fortunately we can pass a nullptr
             // here to get the default behavior
             let opts: *const ffi::rocksdb_wal_readoptions_t = ptr::null();
-            let iter = ffi_try!(ffi::rocksdb_get_updates_since(self.inner, seq_number, opts,));
+            let iter = ffi_try!(ffi::rocksdb_get_updates_since(self.inner, seq_number, opts));
             Ok(DBWALIterator { inner: iter })
         }
     }

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -34,12 +34,22 @@ pub fn opt_bytes_to_ptr<T: AsRef<[u8]>>(opt: Option<T>) -> *const c_char {
 }
 
 macro_rules! ffi_try {
-    ( $($function:ident)::*( $( $arg:expr,)* ) ) => ({
+    ( $($function:ident)::*() ) => {
+        ffi_try_impl!($($function)::*())
+    };
+
+    ( $($function:ident)::*( $arg1:expr $(, $arg:expr)* $(,)? ) ) => {
+        ffi_try_impl!($($function)::*($arg1 $(, $arg)* ,))
+    };
+}
+
+macro_rules! ffi_try_impl {
+    ( $($function:ident)::*( $($arg:expr,)*) ) => {{
         let mut err: *mut ::libc::c_char = ::std::ptr::null_mut();
-        let result = $($function)::*($($arg),*, &mut err);
+        let result = $($function)::*($($arg,)* &mut err);
         if !err.is_null() {
             return Err(Error::new($crate::ffi_util::error_message(err)));
         }
         result
-    })
+    }};
 }


### PR DESCRIPTION
Currently to use the macro a trailing comma is required even if the whole usage fits in a single line, which looks slightly awkward. Change the macro a bit so the trailing comma is optional.

Ran `cargo expand` before and after this change, the output is identical.