### PR TITLE
Add flush_cf method to DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -911,7 +911,7 @@ impl DB {
         &self.path.as_path()
     }
 
-    /// Flush database memtable to SST files on disk (with options).
+    /// Flushes database memtables to SST files on the disk.
     pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_flush(self.inner, flushopts.inner));
@@ -919,12 +919,12 @@ impl DB {
         Ok(())
     }
 
-    /// Flush database memtable to SST files on disk.
+    /// Flushes database memtables to SST files on the disk using default options.
     pub fn flush(&self) -> Result<(), Error> {
         self.flush_opt(&FlushOptions::default())
     }
 
-    /// Flush database memtable to SST files on disk for given column family.
+    /// Flushes database memtables to SST files on the disk for a given column family.
     pub fn flush_cf_opt(&self, cf: &ColumnFamily, flushopts: &FlushOptions) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_flush_cf(self.inner, flushopts.inner, cf.inner));
@@ -932,7 +932,8 @@ impl DB {
         Ok(())
     }
 
-    /// Flush database memtable to SST files on disk for given column family using default option.
+    /// Flushes database memtables to SST files on the disk for a given column family using default
+    /// options.
     pub fn flush_cf(&self, cf: &ColumnFamily) -> Result<(), Error> {
         self.flush_cf_opt(cf, &FlushOptions::default())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -924,6 +924,19 @@ impl DB {
         self.flush_opt(&FlushOptions::default())
     }
 
+    /// Flush database memtable to SST files on disk for given column family.
+    pub fn flush_cf_opt(&self, cf: &ColumnFamily, flushopts: &FlushOptions) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_flush_cf(self.inner, flushopts.inner, cf.inner));
+        }
+        Ok(())
+    }
+
+    /// Flush database memtable to SST files on disk for given column family using default option.
+    pub fn flush_cf(&self, cf: &ColumnFamily) -> Result<(), Error> {
+        self.flush_cf_opt(cf, &FlushOptions::default())
+    }
+
     pub fn write_opt(&self, batch: WriteBatch, writeopts: &WriteOptions) -> Result<(), Error> {
         unsafe {
             ffi_try!(ffi::rocksdb_write(self.inner, writeopts.inner, batch.inner));


### PR DESCRIPTION
The current implementation allows flushing the default column family, but not the rest. This change adds the ability to flush a given column family.