### PR TITLE
Fix potential segfault when calling next on DBIterator that is at the end of the range

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -595,6 +595,10 @@ impl<'a> Iterator for DBIterator<'a> {
     type Item = KVBytes;
 
     fn next(&mut self) -> Option<KVBytes> {
+        if !self.raw.valid() {
+            return None;
+        }
+
         // Initial call to next() after seeking should not move the iterator
         // or the first item will not be returned
         if !self.just_seeked {
@@ -2172,6 +2176,21 @@ fn iterator_test() {
     }
     let opts = Options::default();
     assert!(DB::destroy(&opts, path).is_ok());
+}
+
+#[test]
+fn iterator_test_past_end() {
+    let path = "_rust_rocksdb_iteratortest_past_end";
+    {
+        let db = DB::open_default(path).unwrap();
+        db.put(b"k1", b"v1111").unwrap();
+        let mut iter = db.iterator(IteratorMode::Start);
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
+    }
+    let opts = Options::default();
+    DB::destroy(&opts, path).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
We should not call `next` or `prev` when the internal RocksDB iterator is not valid, otherwise it fails an assertion. The following C++ program demonstrates the behavior:

```
#include <glog/logging.h>
#include <rocksdb/db.h>

int main() {
  rocksdb::Options opts;
  opts.create_if_missing = true;

  char tp[32] = "/tmp/wqfish.XXXXXX";
  char* tmpdir = mkdtemp(tp);

  rocksdb::DB* db;
  auto status = rocksdb::DB::Open(opts, tmpdir, &db);
  CHECK(status.ok());

  auto* iter = db->NewIterator(rocksdb::ReadOptions());
  iter->SeekToFirst();
  iter->Next();

  delete iter;
  delete db;

  return 0;
}
```

Output:

```
main: rocksdb/src/db/db_iter.cc:129: virtual void rocksdb::DBIter::Next(): Assertion `valid_' failed.
```

With this change, we check if the iterator is valid in `next` before doing anything else.

Fixes https://github.com/rust-rocksdb/rust-rocksdb/issues/361