### PR TITLE
Move to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 version = "0.13.0"
+edition = "2018"
 authors = ["Tyler Neely <t@jujit.su>", "David Greenberg <dsg123456789@gmail.com>"]
 license = "Apache-2.0"
 keywords = ["database", "embedded", "LSM-tree", "persistence"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librocksdb-sys"
 version = "6.4.6"
+edition = "2018"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 description = "Native bindings to librocksdb"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,7 +1,3 @@
-extern crate bindgen;
-extern crate cc;
-extern crate glob;
-
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -16,8 +16,6 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
-extern crate libc;
-
 use libc::c_int;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -16,12 +16,10 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 
-use libc::c_int;
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(feature = "bzip2")]
 #[no_mangle]
-pub fn bz_internal_error(errcode: c_int) {
+pub fn bz_internal_error(errcode: libc::c_int) {
     panic!("bz internal error: {}", errcode);
 }

--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -23,8 +23,9 @@
     unused_variables
 )]
 
-use crate::ffi::*;
+use const_cstr::const_cstr;
 use libc::*;
+use librocksdb_sys::*;
 use std::borrow::Cow;
 use std::env;
 use std::ffi::{CStr, CString};

--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -23,13 +23,7 @@
     unused_variables
 )]
 
-#[macro_use]
-extern crate const_cstr;
-extern crate libc;
-extern crate librocksdb_sys as ffi;
-extern crate uuid;
-
-use ffi::*;
+use crate::ffi::*;
 use libc::*;
 use std::borrow::Cow;
 use std::env;
@@ -44,10 +38,6 @@ use uuid::Uuid;
 
 macro_rules! err_println {
     ($($arg:tt)*) => (writeln!(&mut ::std::io::stderr(), $($arg)*).expect("failed printing to stderr"));
-}
-
-macro_rules! cstr {
-    ($($arg:tt)*) => (const_cstr!($($arg)*));
 }
 
 macro_rules! cstrp {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 //
 
-use ffi;
-use {Error, DB};
+use crate::{ffi, Error, DB};
 
 use libc::c_int;
 use std::ffi::CString;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 //
 
-use ffi;
+//! Implementation of bindings to RocksDB Checkpoint[1] API
+//!
+//! [1]: https://github.com/facebook/rocksdb/wiki/Checkpoints
+
+use crate::{ffi, Error, DB};
 use std::ffi::CString;
 use std::path::Path;
-///! Implementation of bindings to RocksDB Checkpoint[1] API
-///
-/// [1]: https://github.com/facebook/rocksdb/wiki/Checkpoints
-use {Error, DB};
 
 /// Undocumented parameter for `ffi::rocksdb_checkpoint_create` function. Zero by default.
 const LOG_SIZE_FOR_FLUSH: u64 = 0_u64;

--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -116,7 +116,7 @@ fn test_filter(level: u32, key: &[u8], value: &[u8]) -> Decision {
 
 #[test]
 fn compaction_filter_test() {
-    use {Options, DB};
+    use crate::{Options, DB};
 
     let path = "_rust_rocksdb_filtertest";
     let mut opts = Options::default();

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 //
 
-use ffi;
-use ffi_util::opt_bytes_to_ptr;
-use {ColumnFamily, ColumnFamilyDescriptor, Error, FlushOptions, Options, WriteOptions, DB};
+use crate::{
+    ffi, ffi_util::opt_bytes_to_ptr, ColumnFamily, ColumnFamilyDescriptor, Error, FlushOptions,
+    Options, WriteOptions, DB,
+};
 
 use libc::{self, c_char, c_int, c_uchar, c_void, size_t};
 use std::collections::BTreeMap;

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -18,14 +18,14 @@ use std::path::Path;
 
 use libc::{self, c_int, c_uchar, c_uint, c_void, size_t};
 
-use compaction_filter::{self, filter_callback, CompactionFilterCallback, CompactionFilterFn};
-use comparator::{self, ComparatorCallback, CompareFn};
-use ffi;
-use merge_operator::{
-    self, full_merge_callback, partial_merge_callback, MergeFn, MergeOperatorCallback,
-};
-use slice_transform::SliceTransform;
-use {
+use crate::{
+    compaction_filter::{self, filter_callback, CompactionFilterCallback, CompactionFilterFn},
+    comparator::{self, ComparatorCallback, CompareFn},
+    ffi,
+    merge_operator::{
+        self, full_merge_callback, partial_merge_callback, MergeFn, MergeOperatorCallback,
+    },
+    slice_transform::SliceTransform,
     BlockBasedIndexType, BlockBasedOptions, DBCompactionStyle, DBCompressionType, DBRecoveryMode,
     FlushOptions, MemtableFactory, Options, PlainTableFactoryOptions, WriteOptions,
 };
@@ -1474,8 +1474,7 @@ impl Default for WriteOptions {
 
 #[cfg(test)]
 mod tests {
-    use MemtableFactory;
-    use Options;
+    use crate::{MemtableFactory, Options};
 
     #[test]
     fn test_enable_statistics() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,6 @@
 //! ```
 //!
 
-extern crate libc;
-extern crate librocksdb_sys as ffi;
-
 #[macro_use]
 mod ffi_util;
 
@@ -69,16 +66,19 @@ mod db_options;
 pub mod merge_operator;
 mod slice_transform;
 
-pub use compaction_filter::Decision as CompactionDecision;
-pub use db::{
-    DBCompactionStyle, DBCompressionType, DBIterator, DBPinnableSlice, DBRawIterator,
-    DBRecoveryMode, DBWALIterator, Direction, IteratorMode, ReadOptions, Snapshot, WriteBatch,
-    WriteBatchIterator,
+pub use crate::{
+    compaction_filter::Decision as CompactionDecision,
+    db::{
+        DBCompactionStyle, DBCompressionType, DBIterator, DBPinnableSlice, DBRawIterator,
+        DBRecoveryMode, DBWALIterator, Direction, IteratorMode, ReadOptions, Snapshot, WriteBatch,
+        WriteBatchIterator,
+    },
+    merge_operator::MergeOperands,
+    slice_transform::SliceTransform,
 };
 
-pub use slice_transform::SliceTransform;
+use librocksdb_sys as ffi;
 
-pub use merge_operator::MergeOperands;
 use std::collections::BTreeMap;
 use std::error;
 use std::fmt;

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -225,7 +225,7 @@ mod test {
 
     #[test]
     fn mergetest() {
-        use {Options, DB};
+        use crate::{Options, DB};
 
         let path = "_rust_rocksdb_mergetest";
         let mut opts = Options::default();
@@ -329,9 +329,9 @@ mod test {
 
     #[test]
     fn counting_mergetest() {
+        use crate::{DBCompactionStyle, Options, DB};
         use std::sync::Arc;
         use std::thread;
-        use {DBCompactionStyle, Options, DB};
 
         let path = "_rust_rocksdb_partial_mergetest";
         let mut opts = Options::default();

--- a/src/slice_transform.rs
+++ b/src/slice_transform.rs
@@ -17,7 +17,7 @@ use std::slice;
 
 use libc::{c_char, c_void, size_t};
 
-use ffi;
+use crate::ffi;
 
 /// A SliceTranform is a generic pluggable way of transforming one string
 /// to another. Its primary use-case is in configuring rocksdb

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
 
 use rocksdb::{
     backup::{BackupEngine, BackupEngineOptions, RestoreOptions},

--- a/tests/test_checkpoint.rs
+++ b/tests/test_checkpoint.rs
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{checkpoint::Checkpoint, Options, DB};
-use util::DBPath;
 
 #[test]
 pub fn test_single_checkpoint() {

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{ColumnFamilyDescriptor, MergeOperands, Options, DB};
-use util::DBPath;
 
 #[test]
 fn test_column_family() {

--- a/tests/test_compationfilter.rs
+++ b/tests/test_compationfilter.rs
@@ -30,8 +30,6 @@ fn test_filter(level: u32, key: &[u8], value: &[u8]) -> CompactionDecision {
 
 #[test]
 fn compaction_filter_test() {
-    use crate::{Options, DB};
-
     let path = DBPath::new("_rust_rocksdb_filtertest");
     let mut opts = Options::default();
     opts.create_if_missing(true);

--- a/tests/test_compationfilter.rs
+++ b/tests/test_compationfilter.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate rocksdb;
-
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{CompactionDecision, Options, DB};
-use util::DBPath;
 
 #[cfg(test)]
 #[allow(unused_variables)]
@@ -32,7 +30,7 @@ fn test_filter(level: u32, key: &[u8], value: &[u8]) -> CompactionDecision {
 
 #[test]
 fn compaction_filter_test() {
-    use {Options, DB};
+    use crate::{Options, DB};
 
     let path = DBPath::new("_rust_rocksdb_filtertest");
     let mut opts = Options::default();

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate libc;
-extern crate rocksdb;
-
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{Error, IteratorMode, Options, Snapshot, WriteBatch, DB};
 use std::sync::Arc;
 use std::{mem, thread};
-use util::DBPath;
 
 #[test]
 fn external() {

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{Direction, IteratorMode, MemtableFactory, Options, DB};
-use util::DBPath;
 
 fn cba(input: &[u8]) -> Box<[u8]> {
     input.to_vec().into_boxed_slice()

--- a/tests/test_multithreaded.rs
+++ b/tests/test_multithreaded.rs
@@ -11,14 +11,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::DB;
 use std::sync::Arc;
 use std::thread;
-use util::DBPath;
 
 const N: usize = 100_000;
 

--- a/tests/test_pinnable_slice.rs
+++ b/tests/test_pinnable_slice.rs
@@ -1,8 +1,7 @@
-extern crate rocksdb;
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{Options, DB};
-use util::DBPath;
 
 #[test]
 fn test_pinnable_slice() {

--- a/tests/test_property.rs
+++ b/tests/test_property.rs
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{Options, DB};
-use util::DBPath;
 
 #[test]
 fn property_test() {

--- a/tests/test_raw_iterator.rs
+++ b/tests/test_raw_iterator.rs
@@ -11,12 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::DB;
-use util::DBPath;
 
 #[test]
 pub fn test_forwards_iteration() {

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -11,13 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
+
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{BlockBasedOptions, Options, ReadOptions, DB};
 use std::{fs, io::Read as _};
-use util::DBPath;
 
 #[test]
 fn test_set_num_levels() {

--- a/tests/test_slice_transform.rs
+++ b/tests/test_slice_transform.rs
@@ -1,8 +1,7 @@
-extern crate rocksdb;
 mod util;
 
+use crate::util::DBPath;
 use rocksdb::{Options, SliceTransform, DB};
-use util::DBPath;
 
 #[test]
 pub fn test_slice_transform() {

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-extern crate rocksdb;
 
 use rocksdb::WriteBatch;
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,5 +1,3 @@
-extern crate rocksdb;
-
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
It has been a while since Rust 2018 released and we should be able to do it now :)

Fixes https://github.com/rust-rocksdb/rust-rocksdb/issues/224