### PR TITLE
Fix doc for WriteBatch::delete

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1765,9 +1765,7 @@ impl WriteBatch {
         }
     }
 
-    /// Remove the database entry for key.
-    ///
-    /// Returns an error if the key was not found.
+    /// Removes the database entry for key. Does nothing if the key was not found.
     pub fn delete<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), Error> {
         let key = key.as_ref();
 


### PR DESCRIPTION
The function does nothing if the key is not found in DB. See https://github.com/facebook/rocksdb/blob/1dd7873e08c1f55dabb8451f1b8795fcdb012887/include/rocksdb/write_batch.h#L85

Fixes https://github.com/rust-rocksdb/rust-rocksdb/issues/352

Also note that these `WriteBatch` functions never return `Err`, so maybe we should change all of them to not return `Result`?