### PR TITLE
Make set_iterate_upper_bound safe

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -130,6 +130,7 @@ pub struct BlockBasedOptions {
 
 pub struct ReadOptions {
     pub(crate) inner: *mut ffi::rocksdb_readoptions_t,
+    iterate_upper_bound: Option<Vec<u8>>,
 }
 
 // Safety note: auto-implementing Send on most db-related types is prevented by the inner FFI
@@ -1612,21 +1613,22 @@ impl ReadOptions {
         }
     }
 
-    /// Set the upper bound for an iterator.
+    /// Sets the upper bound for an iterator.
     /// The upper bound itself is not included on the iteration result.
-    ///
-    /// # Safety
-    ///
-    /// This function will store a clone of key and will give a raw pointer of it to the
-    /// underlying C++ API, therefore, when given to any other [`DB`] method you must ensure
-    /// that this [`ReadOptions`] value does not leave the scope too early (e.g. `DB::iterator_cf_opt`).
-    pub unsafe fn set_iterate_upper_bound<K: AsRef<[u8]>>(&mut self, key: K) {
-        let key = key.as_ref();
-        ffi::rocksdb_readoptions_set_iterate_upper_bound(
-            self.inner,
-            key.as_ptr() as *const c_char,
-            key.len() as size_t,
-        );
+    pub fn set_iterate_upper_bound<K: Into<Vec<u8>>>(&mut self, key: K) {
+        self.iterate_upper_bound = Some(key.into());
+        let upper_bound = self
+            .iterate_upper_bound
+            .as_ref()
+            .expect("iterate_upper_bound must exist.");
+
+        unsafe {
+            ffi::rocksdb_readoptions_set_iterate_upper_bound(
+                self.inner,
+                upper_bound.as_ptr() as *const c_char,
+                upper_bound.len() as size_t,
+            );
+        }
     }
 
     pub fn set_prefix_same_as_start(&mut self, v: bool) {
@@ -1679,6 +1681,7 @@ impl Default for ReadOptions {
         unsafe {
             ReadOptions {
                 inner: ffi::rocksdb_readoptions_create(),
+                iterate_upper_bound: None,
             }
         }
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -54,7 +54,7 @@ impl<'a> Snapshot<'a> {
 
     pub fn iterator_opt(&self, mode: IteratorMode, mut readopts: ReadOptions) -> DBIterator<'a> {
         readopts.set_snapshot(self);
-        DBIterator::new(self.db, &readopts, mode)
+        DBIterator::new(self.db, readopts, mode)
     }
 
     pub fn iterator_cf_opt(
@@ -64,7 +64,7 @@ impl<'a> Snapshot<'a> {
         mode: IteratorMode,
     ) -> DBIterator {
         readopts.set_snapshot(self);
-        DBIterator::new_cf(self.db, cf_handle, &readopts, mode)
+        DBIterator::new_cf(self.db, cf_handle, readopts, mode)
     }
 
     /// Opens a raw iterator over the data in this snapshot, using the default read options.
@@ -82,7 +82,7 @@ impl<'a> Snapshot<'a> {
     /// Opens a raw iterator over the data in this snapshot, using the given read options.
     pub fn raw_iterator_opt(&self, mut readopts: ReadOptions) -> DBRawIterator {
         readopts.set_snapshot(self);
-        DBRawIterator::new(self.db, &readopts)
+        DBRawIterator::new(self.db, readopts)
     }
 
     /// Opens a raw iterator over the data in this snapshot under the given column family, using the given read options.
@@ -92,7 +92,7 @@ impl<'a> Snapshot<'a> {
         mut readopts: ReadOptions,
     ) -> DBRawIterator {
         readopts.set_snapshot(self);
-        DBRawIterator::new_cf(self.db, cf_handle, &readopts)
+        DBRawIterator::new_cf(self.db, cf_handle, readopts)
     }
 
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Error> {


### PR DESCRIPTION
This function is probably the only unsafe public API of this library. The unsafe version is not super easy to use since it requires the user to carefully make sure the buffer is alive. For example, the following
usage would be incorrect:

```
let mut opts = ReadOptions::default();
let upper_bound = b"k4".to_vec();
unsafe {
    opts.set_iterate_upper_bound(upper_bound);
}
```

A relatively easy way to make it safe is to store the buffer inside `ReadOptions` and store `ReadOptions` inside the iterator, so the buffer will not be dropped when the iterator is being used.

Fixes https://github.com/rust-rocksdb/rust-rocksdb/issues/299
Fixes https://github.com/rust-rocksdb/rust-rocksdb/issues/329