### PR TITLE
Fix building librocksdb-sys with system libraries

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -26,7 +26,7 @@ fn fail_on_empty_directory(name: &str) {
     }
 }
 
-fn rocksdb_include_dir() -> std::string::String {
+fn rocksdb_include_dir() -> String {
     match env::var("ROCKSDB_INCLUDE_DIR") {
         Ok(val) => return val,
         Err(_) => return "rocksdb/include".to_string(),

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -323,10 +323,10 @@ fn main() {
     if cfg!(feature = "zstd") && !try_to_find_and_link_lib("ZSTD") {
         build_zstd();
     }
-    if cfg!(feature = "zlib") && !try_to_find_and_link_lib("ZLIB") {
+    if cfg!(feature = "zlib") && !try_to_find_and_link_lib("Z") {
         build_zlib();
     }
-    if cfg!(feature = "bzip2") && !try_to_find_and_link_lib("BZIP2") {
+    if cfg!(feature = "bzip2") && !try_to_find_and_link_lib("BZ2") {
         build_bzip2();
     }
 }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -295,38 +295,37 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=rocksdb/");
-    println!("cargo:rerun-if-changed=snappy/");
-    println!("cargo:rerun-if-changed=lz4/");
-    println!("cargo:rerun-if-changed=zstd/");
-    println!("cargo:rerun-if-changed=zlib/");
-    println!("cargo:rerun-if-changed=bzip2/");
-
-    fail_on_empty_directory("rocksdb");
-    fail_on_empty_directory("snappy");
-    fail_on_empty_directory("lz4");
-    fail_on_empty_directory("zstd");
-    fail_on_empty_directory("zlib");
-    fail_on_empty_directory("bzip2");
 
     bindgen_rocksdb();
 
     if !try_to_find_and_link_lib("ROCKSDB") {
+        println!("cargo:rerun-if-changed=rocksdb/");
+        fail_on_empty_directory("rocksdb");
         build_rocksdb();
     }
     if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
+        println!("cargo:rerun-if-changed=snappy/");
+        fail_on_empty_directory("snappy");
         build_snappy();
     }
     if cfg!(feature = "lz4") && !try_to_find_and_link_lib("LZ4") {
+        println!("cargo:rerun-if-changed=lz4/");
+        fail_on_empty_directory("lz4");
         build_lz4();
     }
     if cfg!(feature = "zstd") && !try_to_find_and_link_lib("ZSTD") {
+        println!("cargo:rerun-if-changed=zstd/");
+        fail_on_empty_directory("zstd");
         build_zstd();
     }
     if cfg!(feature = "zlib") && !try_to_find_and_link_lib("Z") {
+        println!("cargo:rerun-if-changed=zlib/");
+        fail_on_empty_directory("zlib");
         build_zlib();
     }
     if cfg!(feature = "bzip2") && !try_to_find_and_link_lib("BZ2") {
+        println!("cargo:rerun-if-changed=bzip2/");
+        fail_on_empty_directory("bzip2");
         build_bzip2();
     }
 }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -26,9 +26,16 @@ fn fail_on_empty_directory(name: &str) {
     }
 }
 
+fn rocksdb_include_dir() -> std::string::String {
+    match env::var("ROCKSDB_INCLUDE_DIR") {
+        Ok(val) => return val,
+        Err(_) => return "rocksdb/include".to_string(),
+    };
+}
+
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
-        .header("rocksdb/include/rocksdb/c.h")
+        .header(rocksdb_include_dir() + "/rocksdb/c.h")
         .derive_debug(false)
         .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")


### PR DESCRIPTION
This PR:

 * Uses the correct names for the zlib and bzip2 libraries. The zlib library is called `libz.a` and the bzip2 library is called `libbz2.a`.

* Only fails on empty sub-module directories when the librocksdb-sys is configured to build them.

* Parameterize the rocksdb include directory.