### PR TITLE
Make DBPath use tempfile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ librocksdb-sys = { path = "librocksdb-sys", version = "6.4.6" }
 
 [dev-dependencies]
 trybuild = "1.0.21"
+tempfile = "3.1.0"

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod util;
+use crate::util::DBPath;
+
 use rocksdb::{
     backup::{BackupEngine, BackupEngineOptions, RestoreOptions},
     Options, DB,
@@ -20,12 +23,12 @@ use rocksdb::{
 #[test]
 fn backup_restore() {
     // create backup
-    let path = "_rust_rocksdb_backup_test";
-    let restore_path = "_rust_rocksdb_restore_from_backup_path";
+    let path = DBPath::new("backup_test");
+    let restore_path = DBPath::new("restore_from_backup_path");
     let mut opts = Options::default();
     opts.create_if_missing(true);
     {
-        let db = DB::open(&opts, path).unwrap();
+        let db = DB::open(&opts, &path).unwrap();
         assert!(db.put(b"k1", b"v1111").is_ok());
         let value = db.get(b"k1");
         assert_eq!(value.unwrap().unwrap(), b"v1111");
@@ -44,11 +47,9 @@ fn backup_restore() {
             );
             assert!(restore_status.is_ok());
 
-            let db_restore = DB::open_default(restore_path).unwrap();
+            let db_restore = DB::open_default(&restore_path).unwrap();
             let value = db_restore.get(b"k1");
             assert_eq!(value.unwrap().unwrap(), b"v1111");
         }
     }
-    assert!(DB::destroy(&opts, restore_path).is_ok());
-    assert!(DB::destroy(&opts, path).is_ok());
 }

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -253,7 +253,7 @@ fn test_prefix_iterator_uses_full_prefix() {
 
 #[test]
 fn test_full_iterator() {
-    let path = "_rust_rocksdb_fulliteratortest";
+    let path = DBPath::new("fulliteratortest");
     {
         let a1: Box<[u8]> = key(b"aaa1");
         let a2: Box<[u8]> = key(b"aaa2");
@@ -273,7 +273,7 @@ fn test_full_iterator() {
         opts.set_allow_concurrent_memtable_write(false);
         opts.set_memtable_factory(factory);
 
-        let db = DB::open(&opts, path).unwrap();
+        let db = DB::open(&opts, &path).unwrap();
 
         assert!(db.put(&*a1, &*a1).is_ok());
         assert!(db.put(&*a2, &*a2).is_ok());
@@ -295,8 +295,6 @@ fn test_full_iterator() {
         let a_iterator = db.full_iterator(IteratorMode::Start);
         assert_eq!(a_iterator.collect::<Vec<_>>(), expected)
     }
-    let opts = Options::default();
-    assert!(DB::destroy(&opts, path).is_ok());
 }
 
 fn custom_iter<'a>(db: &'a DB) -> impl Iterator<Item = usize> + 'a {
@@ -313,8 +311,6 @@ fn test_custom_iterator() {
         let db = DB::open(&opts, &path).unwrap();
         let _data = custom_iter(&db).collect::<Vec<usize>>();
     }
-    let opts = Options::default();
-    assert!(DB::destroy(&opts, path).is_ok());
 }
 
 #[test]

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -69,7 +69,7 @@ fn test_block_based_options() {
         let _db = DB::open(&opts, &n).unwrap();
 
         // read the setting from the LOG file
-        let mut rocksdb_log = fs::File::open(format!("{}/LOG", n.as_ref().to_str().unwrap()))
+        let mut rocksdb_log = fs::File::open(format!("{}/LOG", (&n).as_ref().to_str().unwrap()))
             .expect("rocksdb creates a LOG file");
         let mut settings = String::new();
         rocksdb_log.read_to_string(&mut settings).unwrap();


### PR DESCRIPTION
This ensures no collisions when running tests in a multithreaded manner,
and avoids cluttering up the repo's directory with temp files.

Step one in allowing `cargo watch` to work correctly; more cleanup is
needed before we stop making any files in the repo's directory.

This also helps to prevent bugs where DBPath's drop() could run early
because the DBPath itself (not a reference) was passed into something
like DB::open and dropped immediately, destroying the database.

---

I'm planning to try and get functionality like #250 merged, starting with 
things that are easy to peel off like this. (This is a slightly different approach
 from #250 which I hope seems reasonable.)

Easy follow-ups I'm doing in https://github.com/jder/rust-rocksdb/tree/db-path-temp-full
(could be this PR if preferred; not sure how much people are OK with in one PR):
  - [x] delete tests from db.rs which are duplicated in tests/test_db.rs
  - [x] move remaining tests over to use DBPath where possible, tempfile where not
  - [x] remove `_rust_rocksdb_` from all the DBPath names (and from .gitignore)
  - [x] rename DBPath to TemporaryDBPath as in #250. 
  - [x] remove path argument from TemporaryDBPath as in #250
