### PR TITLE
check for endianness when building snappy

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -174,6 +174,7 @@ fn build_rocksdb() {
 
 fn build_snappy() {
     let target = env::var("TARGET").unwrap();
+    let endianness = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
 
     let mut config = cc::Build::new();
     config.include("snappy/");
@@ -185,6 +186,10 @@ fn build_snappy() {
         config.flag("-EHsc");
     } else {
         config.flag("-std=c++11");
+    }
+
+    if endianness == "big" {
+        config.define("WORDS_BIGENDIAN", Some("1"));
     }
 
     config.file("snappy/snappy.cc");


### PR DESCRIPTION
Hey,

snappy's build process usually involves a configuration step which detects whether it is build on a big or little endian system. Since the `librocksdb-sys` uses a `build.rs` that step is skipped and snappy ends up being built for little endian even if on a big endian system. This small patch should change this behaviour.