### PR TITLE
Update doc for Options::set_compression_type

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -511,11 +511,10 @@ impl Options {
         }
     }
 
-    /// Sets the compression algorithm that will be used for the bottommost level that
-    /// contain files. If level-compaction is used, this option will only affect
-    /// levels after base level.
+    /// Sets the compression algorithm that will be used for compressing blocks.
     ///
-    /// Default: DBCompressionType::None
+    /// Default: `DBCompressionType::Snappy` (`DBCompressionType::None` if
+    /// snappy feature is not enabled).
     ///
     /// # Example
     ///


### PR DESCRIPTION
The current description of this methods sounds like the description for [bottommost_compression](https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L229), which we don't expose at the moment. Also the default type is snappy as long as it's enabled: https://github.com/facebook/rocksdb/blob/4cbc19d2a1da1a44775f27c2d167a0d8da0fd9f5/options/options.cc#L99