### PR TITLE
Use DBPath for backup_restore test and remove _rust_rocksdb* from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ target
 Cargo.lock
 *.orig
 *.bk
-_rust_rocksdb*
 *rlib
 tags
 path

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -16,7 +16,7 @@ mod util;
 
 use rocksdb::{
     backup::{BackupEngine, BackupEngineOptions, RestoreOptions},
-    Options, DB,
+    DB,
 };
 use util::DBPath;
 
@@ -25,15 +25,13 @@ fn backup_restore() {
     // create backup
     let path = DBPath::new("backup_test");
     let restore_path = DBPath::new("restore_from_backup_path");
-    let mut opts = Options::default();
-    opts.create_if_missing(true);
     {
-        let db = DB::open(&opts, &path).unwrap();
+        let db = DB::open_default(&path).unwrap();
         assert!(db.put(b"k1", b"v1111").is_ok());
         let value = db.get(b"k1");
         assert_eq!(value.unwrap().unwrap(), b"v1111");
         {
-            let backup_path = "_rust_rocksdb_backup_path";
+            let backup_path = DBPath::new("backup_path");
             let backup_opts = BackupEngineOptions::default();
             let mut backup_engine = BackupEngine::open(&backup_opts, &backup_path).unwrap();
             assert!(backup_engine.create_new_backup(&db).is_ok());


### PR DESCRIPTION
Migrate everything to use tempdir so we do not create these directories in project root when running tests.