### PR TITLE
Allow to build RocksDB with a different stdlib.

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -312,16 +312,13 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 }
 
 fn cxx_standard() -> String {
-    env::var("ROCKSDB_CXX_STDLIB").map_or_else(
-        |_| "-std=c++11".to_owned(),
-        |lib| {
-            if !lib.starts_with("-std=") {
-                format!("-std={}", lib)
-            } else {
-                lib
-            }
-        },
-    )
+    env::var("ROCKSDB_CXX_STD").map_or("-std=c++11".to_owned(), |cxx_std| {
+        if !cxx_std.starts_with("-std=") {
+            format!("-std={}", cxx_std)
+        } else {
+            cxx_std
+        }
+    })
 }
 
 fn main() {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -163,7 +163,7 @@ fn build_rocksdb() {
     if target.contains("msvc") {
         config.flag("-EHsc");
     } else {
-        config.flag(&stdlib_flag());
+        config.flag(&cxx_standard());
         // this was breaking the build on travis due to
         // > 4mb of warnings emitted.
         config.flag("-Wno-unused-parameter");
@@ -311,7 +311,7 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     false
 }
 
-fn stdlib_flag() -> String {
+fn cxx_standard() -> String {
     let lib = env::var("ROCKSDB_CXX_STDLIB").unwrap_or_else(|_| "-std=c++11".to_owned());
     if !lib.starts_with("-std=") {
         return format!("-std={}", lib);

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -163,7 +163,7 @@ fn build_rocksdb() {
     if target.contains("msvc") {
         config.flag("-EHsc");
     } else {
-        config.flag("-std=c++11");
+        config.flag(&stdlib_flag());
         // this was breaking the build on travis due to
         // > 4mb of warnings emitted.
         config.flag("-Wno-unused-parameter");
@@ -193,6 +193,8 @@ fn build_snappy() {
     if target.contains("msvc") {
         config.flag("-EHsc");
     } else {
+        // Snappy requires C++11.
+        // See: https://github.com/google/snappy/blob/master/CMakeLists.txt#L32-L38
         config.flag("-std=c++11");
     }
 
@@ -307,6 +309,15 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
         return true;
     }
     false
+}
+
+fn stdlib_flag() -> String {
+    let lib = env::var("ROCKSDB_CXX_STDLIB").unwrap_or_else(|_| "-std=c++11".to_owned());
+    if !lib.starts_with("-std=") {
+        return format!("-std={}", lib);
+    }
+
+    lib
 }
 
 fn main() {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -312,12 +312,16 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 }
 
 fn cxx_standard() -> String {
-    let lib = env::var("ROCKSDB_CXX_STDLIB").unwrap_or_else(|_| "-std=c++11".to_owned());
-    if !lib.starts_with("-std=") {
-        return format!("-std={}", lib);
-    }
-
-    lib
+    env::var("ROCKSDB_CXX_STDLIB").map_or_else(
+        |_| "-std=c++11".to_owned(),
+        |lib| {
+            if !lib.starts_with("-std=") {
+                format!("-std={}", lib)
+            } else {
+                lib
+            }
+        },
+    )
 }
 
 fn main() {


### PR DESCRIPTION
RocksDB supports up to C++20, so this should be configurable.

I've left the default value as it currently is.

Signed-off-by: David Calavera <david.calavera@gmail.com>