### PR TITLE
Fixed build for x86_64-linux-android that doesn't support PCLMUL

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -103,12 +103,15 @@ fn build_rocksdb() {
         // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
         // only available since Intel Nehalem (about 2010) and AMD Bulldozer
         // (about 2011).
-        config.define("HAVE_PCLMUL", Some("1"));
         config.define("HAVE_SSE42", Some("1"));
         config.flag_if_supported("-msse2");
         config.flag_if_supported("-msse4.1");
         config.flag_if_supported("-msse4.2");
-        config.flag_if_supported("-mpclmul");
+
+        if !target.contains("android") {
+            config.define("HAVE_PCLMUL", Some("1"));
+            config.flag_if_supported("-mpclmul");
+        }
     }
 
     if target.contains("darwin") {


### PR DESCRIPTION
I checked build for the most popular Android targets: aarch64-linux-android, armv7-linux-androideabi, i686-linux-android and  x86_64-linux-android.

The build works fine for aarch64, i686, armv7, but breaks on `x86_64-linux-android` due compiling PCLMUL based code while clang complains about missed target feature `pclmul`.

```
cargo:warning=rocksdb/util/crc32c.cc:667:21: error: '__builtin_ia32_pclmulqdq128' needs target feature pclmul
cargo:warning=  const auto res0 = _mm_clmulepi64_si128(crc0_xmm, multiplier, 0x00);
cargo:warning=                    ^
cargo:warning=/usr/local/Caskroom/android-ndk/21/android-ndk-r21/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/9.0.8/include/__wmmintrin_pclmul.h:45:13: note: expanded from macro '_mm_clmulepi64_si128'
cargo:warning=  ((__m128i)__builtin_ia32_pclmulqdq128((__v2di)(__m128i)(X), \
cargo:warning=            ^
cargo:warning=rocksdb/util/crc32c.cc:669:21: error: '__builtin_ia32_pclmulqdq128' needs target feature pclmul
cargo:warning=  const auto res1 = _mm_clmulepi64_si128(crc1_xmm, multiplier, 0x10);
cargo:warning=                    ^
cargo:warning=/usr/local/Caskroom/android-ndk/21/android-ndk-r21/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/9.0.8/include/__wmmintrin_pclmul.h:45:13: note: expanded from macro '_mm_clmulepi64_si128'
cargo:warning=  ((__m128i)__builtin_ia32_pclmulqdq128((__v2di)(__m128i)(X), \
cargo:warning=            ^
cargo:warning=2 errors generated.
```

To fix this PR disables PCLMUL support for x86_64-linux-android triplet.