### PR TITLE
librocksdb-sys: do not set rerun-if-changed=build.rs

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -325,8 +325,6 @@ fn cxx_standard() -> String {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
     bindgen_rocksdb();
 
     if !try_to_find_and_link_lib("ROCKSDB") {


### PR DESCRIPTION
This is unnecessary as per the Cargo book:

> Cargo automatically handles whether or not the script itself needs to
> be recompiled, and of course the script will be re-run after it has
> been recompiled. Otherwise, specifying build.rs is redundant and unnecessary.

https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed

Additionally, this sometimes causes the rocksdb being unnecessarily
recomputed whenever I make any change in the downstream project.
And it takes a long time to finish.