### PR TITLE
Fix building librocksdb-sys with system libraries (#393)

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -30,9 +30,16 @@ fn fail_on_empty_directory(name: &str) {
     }
 }
 
+fn rocksdb_include_dir() -> String {
+    match env::var("ROCKSDB_INCLUDE_DIR") {
+        Ok(val) => return val,
+        Err(_) => return "rocksdb/include".to_string(),
+    };
+}
+
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
-        .header("rocksdb/include/rocksdb/c.h")
+        .header(rocksdb_include_dir() + "/rocksdb/c.h")
         .blacklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
         .generate()
@@ -273,38 +280,37 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=rocksdb/");
-    println!("cargo:rerun-if-changed=snappy/");
-    println!("cargo:rerun-if-changed=lz4/");
-    println!("cargo:rerun-if-changed=zstd/");
-    println!("cargo:rerun-if-changed=zlib/");
-    println!("cargo:rerun-if-changed=bzip2/");
-
-    fail_on_empty_directory("rocksdb");
-    fail_on_empty_directory("snappy");
-    fail_on_empty_directory("lz4");
-    fail_on_empty_directory("zstd");
-    fail_on_empty_directory("zlib");
-    fail_on_empty_directory("bzip2");
 
     bindgen_rocksdb();
 
     if !try_to_find_and_link_lib("ROCKSDB") {
+        println!("cargo:rerun-if-changed=rocksdb/");
+        fail_on_empty_directory("rocksdb");
         build_rocksdb();
     }
     if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
+        println!("cargo:rerun-if-changed=snappy/");
+        fail_on_empty_directory("snappy");
         build_snappy();
     }
     if cfg!(feature = "lz4") && !try_to_find_and_link_lib("LZ4") {
+        println!("cargo:rerun-if-changed=lz4/");
+        fail_on_empty_directory("lz4");
         build_lz4();
     }
     if cfg!(feature = "zstd") && !try_to_find_and_link_lib("ZSTD") {
+        println!("cargo:rerun-if-changed=zstd/");
+        fail_on_empty_directory("zstd");
         build_zstd();
     }
-    if cfg!(feature = "zlib") && !try_to_find_and_link_lib("ZLIB") {
+    if cfg!(feature = "zlib") && !try_to_find_and_link_lib("Z") {
+        println!("cargo:rerun-if-changed=zlib/");
+        fail_on_empty_directory("zlib");
         build_zlib();
     }
-    if cfg!(feature = "bzip2") && !try_to_find_and_link_lib("BZIP2") {
+    if cfg!(feature = "bzip2") && !try_to_find_and_link_lib("BZ2") {
+        println!("cargo:rerun-if-changed=bzip2/");
+        fail_on_empty_directory("bzip2");
         build_bzip2();
     }
 }


### PR DESCRIPTION
This backports the fix from 8a7996e943d4ba56fc32f9e657e8a3cd41b83d1e into `librocksdb-sys` 5.18.3

I'd like to ask for a new release of `librocksdb-sys` with this patch applied (5.18.4 or 5.18.3.1).