### PR TITLE
Removed unneeded bindgen features

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -29,5 +29,5 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [build-dependencies]
 cc = { version = "^1.0", features = ["parallel"] }
-bindgen = "0.55"
+bindgen = { version = "0.55", default-features = false, features = ["runtime"] }
 glob = "0.3"


### PR DESCRIPTION
Some features of bindgen are not needed when building the library and
lead to unused dependencies (mainly `clap`). This change deactivates all
`bindgen` features except for `runtime` which is required for build to
work.

This improved debug build time by ~13 seconds and (surprisingly) release
build time by ~9 seconds. But perhaps improved security is more
interesting.

I can post the outputs from `-Z timings` somewhere if you want, but I don't know where to put it to be accepted and rendered - LMK if you know of a good website. The files have above 200-250k.

I intend to backport this into 12.2 after it's accepted.