### PR TITLE
Removed unneeded bindgen features (backport)

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -30,5 +30,5 @@ uuid = { version = "0.7", features = ["v4"] }
 
 [build-dependencies]
 cc = { version = "^1.0", features = ["parallel"] }
-bindgen = "0.47"
+bindgen = { version = "0.49.3", default-features = false }
 glob = "0.2.11"


### PR DESCRIPTION
Some features of bindgen are not needed when building the library and
lead to unused dependencies (mainly `clap`). This change deactivates all
`bindgen` features except for `runtime` which is required for build to
work.

I had to bump bindgen for it to have effect, so I'm not sure if your want to do such change in this branch. If not I would understand it.