### PR TITLE
fix: merge delete_callback omitted by mistake

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -962,7 +962,7 @@ impl Options {
                 Some(merge_operator::destructor_callback::<F, F>),
                 Some(full_merge_callback::<F, F>),
                 Some(partial_merge_callback::<F, F>),
-                None,
+                Some(merge_operator::delete_callback),
                 Some(merge_operator::name_callback::<F, F>),
             );
             ffi::rocksdb_options_set_merge_operator(self.inner, mo);
@@ -987,7 +987,7 @@ impl Options {
                 Some(merge_operator::destructor_callback::<F, PF>),
                 Some(full_merge_callback::<F, PF>),
                 Some(partial_merge_callback::<F, PF>),
-                None,
+                Some(merge_operator::delete_callback),
                 Some(merge_operator::name_callback::<F, PF>),
             );
             ffi::rocksdb_options_set_merge_operator(self.inner, mo);


### PR DESCRIPTION
https://github.com/rust-rocksdb/rust-rocksdb/pull/457  make a change
> The merge result Vec<u8> is turned into a boxed slice and turned into raw pointer by Box::into_raw. In delete_callback, Box::from_raw is called to wrap the raw pointer back and the original memory will be released here.

https://github.com/rust-rocksdb/rust-rocksdb/pull/481 omit `delete_callback` by mistake.

According
```
if (delete_value_ != nullptr) {
      (*delete_value_)(state_, tmp_new_value, new_value_len);
} else {
      free(tmp_new_value);
}
```
https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw
https://doc.rust-lang.org/nomicon/ffi.html#destructors
I think this is UB.

fix https://github.com/rust-rocksdb/rust-rocksdb/issues/494