### PR TITLE
Add DB::open_cf_with_ttl method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bump `librocksdb-sys` up to 6.13.3 (aleksuss)
 * Add `multi_get`, `multi_get_opt`, `multi_get_cf` and `multi_get_cf_opt` `DB` methods (stanislav-tkach)
 * Bump `librocksdb-sys` up to 6.17.3 (ordian)
+* Add `DB::open_cf_with_ttl` method (fdeantoni)
 
 ## 0.15.0 (2020-08-25)
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -111,6 +111,8 @@ impl DB {
     }
 
     /// Opens the database with a Time to Live compaction filter and column family names.
+    ///
+    /// Column families opened using this function will be created with default `Options`.    
     pub fn open_cf_with_ttl<P, I, N>(
         opts: &Options,
         path: P,
@@ -126,6 +128,21 @@ impl DB {
             .into_iter()
             .map(|name| ColumnFamilyDescriptor::new(name.as_ref(), Options::default()));
 
+        DB::open_cf_descriptors_with_ttl(opts, path, cfs, ttl)
+    }
+
+    /// Opens a database with the given database with a Time to Live compaction filter and
+    /// column family descriptors.
+    pub fn open_cf_descriptors_with_ttl<P, I>(
+        opts: &Options,
+        path: P,
+        cfs: I,
+        ttl: Duration,
+    ) -> Result<DB, Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
         DB::open_cf_descriptors_internal(opts, path, cfs, &AccessType::WithTTL { ttl })
     }
 

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -529,6 +529,25 @@ fn test_open_with_ttl() {
 }
 
 #[test]
+fn test_open_cf_with_ttl() {
+    let path = DBPath::new("_rust_rocksdb_test_open_cf_with_ttl");
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let db = DB::open_cf_with_ttl(&opts, &path, &["test_cf"], Duration::from_secs(1)).unwrap();
+    let cf = db.cf_handle("test_cf").unwrap();
+    db.put_cf(cf, b"key1", b"value1").unwrap();
+
+    thread::sleep(Duration::from_secs(2));
+    // Trigger a manual compaction, this will check the TTL filter
+    // in the database and drop all expired entries.
+    db.compact_range_cf(cf, None::<&[u8]>, None::<&[u8]>);
+
+    assert!(db.get_cf(cf, b"key1").unwrap().is_none());
+}
+
+#[test]
 fn compact_range_test() {
     let path = DBPath::new("_rust_rocksdb_compact_range_test");
     {


### PR DESCRIPTION
Added the ability to open a database with column families and TTL. It uses method `ffi::rocksdb_open_column_families_with_ttl`.