### PR TITLE
Make SSE inclusion conditional for target features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Bump `librocksdb-sys` up to 6.19.3 (olegnn)
+* Make SSE inclusion conditional for target features (mbargull)
 
 ## 0.16.0 (2021-04-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 * Bump `librocksdb-sys` up to 6.19.3 (olegnn)
-* Make SSE inclusion conditional for target features (mbargull)
+* Make SSE inclusion conditional for target features.
+  RocksDB is not compiled with SSE4 instructions anymore unless the corresponding features are enabled in rustc (mbargull)
 * Bump `librocksdb-sys` up to 6.20.3 (olegnn, akrylysov)
 * Add `DB::key_may_exist_cf_opt` method (stanislav-tkach)
 * Add `Options::set_zstd_max_train_bytes` method (stanislav-tkach)

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -103,14 +103,24 @@ fn build_rocksdb() {
         // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
         // only available since Intel Nehalem (about 2010) and AMD Bulldozer
         // (about 2011).
-        config.define("HAVE_SSE42", Some("1"));
-        config.flag_if_supported("-msse2");
-        config.flag_if_supported("-msse4.1");
-        config.flag_if_supported("-msse4.2");
+        let target_feature = env::var("CARGO_CFG_TARGET_FEATURE").unwrap();
+        let target_features: Vec<_> = target_feature.split(",").collect();
+        if target_features.contains(&"sse2") {
+            config.flag_if_supported("-msse2");
+        }
+        if target_features.contains(&"sse4.1") {
+            config.flag_if_supported("-msse4.1");
+        }
+        if target_features.contains(&"sse4.2") {
+            config.flag_if_supported("-msse4.2");
+            config.define("HAVE_SSE42", Some("1"));
+        }
 
         if !target.contains("android") {
-            config.define("HAVE_PCLMUL", Some("1"));
-            config.flag_if_supported("-mpclmul");
+            if target_features.contains(&"pclmulqdq") {
+                config.define("HAVE_PCLMUL", Some("1"));
+                config.flag_if_supported("-mpclmul");
+            }
         }
     }
 


### PR DESCRIPTION
Since `0.12.3`/gh-295 the underlying library gets compiled with SSE4.1/SSE4.2/PCLMUL instructions unconditionally.
This prevents building the library for backwards compatible binaries, e.g., for `target-cpu=nocona` you'd want a binary without SSE4 instructions.
With the changes proposed here, one still can freely build for `target-cpu=nehalem` (or `target-cpu=westmere` to get PCLMUL), or just `target-cpu=native` given a recent enough machine and for local deployment. And additionally `target-cpu=nocona` would yield the desired compatible build.

(Context here is that `rust-rocksdb` is used by some programs we distribute as binaries for [Bioconda](https://bioconda.github.io) and currently/usually target older CPU architectures there.)