### PR TITLE
Mark Cache and Env as Send and Sync

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -384,6 +384,8 @@ unsafe impl Send for BlockBasedOptions {}
 unsafe impl Send for CuckooTableOptions {}
 unsafe impl Send for ReadOptions {}
 unsafe impl Send for IngestExternalFileOptions {}
+unsafe impl Send for Cache {}
+unsafe impl Send for Env {}
 
 // Sync is similarly safe for many types because they do not expose interior mutability, and their
 // use within the rocksdb library is generally behind a const reference
@@ -393,6 +395,8 @@ unsafe impl Sync for BlockBasedOptions {}
 unsafe impl Sync for CuckooTableOptions {}
 unsafe impl Sync for ReadOptions {}
 unsafe impl Sync for IngestExternalFileOptions {}
+unsafe impl Sync for Cache {}
+unsafe impl Sync for Env {}
 
 impl Drop for Options {
     fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,9 +172,10 @@ impl fmt::Display for Error {
 #[cfg(test)]
 mod test {
     use super::{
-        BlockBasedOptions, BoundColumnFamily, ColumnFamily, ColumnFamilyDescriptor, DBIterator,
-        DBRawIterator, IngestExternalFileOptions, Options, PlainTableFactoryOptions, ReadOptions,
-        Snapshot, SstFileWriter, WriteBatch, WriteOptions, DB,
+        BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamily, ColumnFamilyDescriptor,
+        DBIterator, DBRawIterator, Env, IngestExternalFileOptions, Options,
+        PlainTableFactoryOptions, ReadOptions, Snapshot, SstFileWriter, WriteBatch, WriteOptions,
+        DB,
     };
 
     #[test]
@@ -201,6 +202,8 @@ mod test {
         is_send::<BoundColumnFamily<'_>>();
         is_send::<SstFileWriter>();
         is_send::<WriteBatch>();
+        is_send::<Cache>();
+        is_send::<Env>();
     }
 
     #[test]
@@ -221,5 +224,7 @@ mod test {
         is_sync::<PlainTableFactoryOptions>();
         is_sync::<ColumnFamilyDescriptor>();
         is_sync::<SstFileWriter>();
+        is_sync::<Cache>();
+        is_sync::<Env>();
     }
 }


### PR DESCRIPTION
Similarly to other types in `db_options.rs`, `Cache` and `Env` are Send-safe and Sync-safe.