### PR TITLE
Add WAL flush API

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -589,6 +589,15 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
         &self.path.as_path()
     }
 
+    /// Flushes the WAL buffer. If `sync` is set to `true`, also syncs
+    /// the data to disk.
+    pub fn flush_wal(&self, sync: bool) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_flush_wal(self.inner, sync as u8));
+        }
+        Ok(())
+    }
+
     /// Flushes database memtables to SST files on the disk.
     pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
         unsafe {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2650,6 +2650,26 @@ impl Options {
         }
     }
 
+    /// If enabled, WAL is not flushed automatically after each write. Instead it
+    /// relies on manual invocation of `DB::flush_wal()` to write the WAL buffer
+    /// to its file.
+    ///
+    /// Default: false
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rocksdb::Options;
+    ///
+    /// let mut options = Options::default();
+    /// options.set_manual_wal_flush(true);
+    /// ```
+    pub fn set_manual_wal_flush(&mut self, is_enabled: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_manual_wal_flush(self.inner, is_enabled as c_uchar);
+        }
+    }
+
     /// Guarantee that all column families are flushed together atomically.
     /// This option applies to both manual flushes (`db.flush()`) and automatic
     /// background flushes caused when memtables are filled.


### PR DESCRIPTION
Exposes the WAL flush API. More information about this API can be found here[1].

[1] https://rocksdb.org/blog/2017/08/25/flushwal.html