### PR TITLE
Support building RocksDB with jemalloc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,3 +99,8 @@ jobs:
         with:
           command: test
           args: --features multi-threaded-cf
+      - name: Run rocksdb tests (jemalloc)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features jemalloc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,7 @@ jobs:
           command: test
           args: --features multi-threaded-cf
       - name: Run rocksdb tests (jemalloc)
+        if: runner.os != 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib", "bzip2"]
+jemalloc = ["librocksdb-sys/jemalloc"]
 valgrind = []
 snappy = ["librocksdb-sys/snappy"]
 lz4 = ["librocksdb-sys/lz4"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -13,6 +13,7 @@ links = "rocksdb"
 
 [features]
 default = [ "static" ]
+jemalloc = ["jemalloc-sys"]
 static = []
 snappy = []
 lz4 = []
@@ -22,6 +23,7 @@ bzip2 = []
 
 [dependencies]
 libc = "0.2"
+jemalloc-sys = { version = "0.3", features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 
 [dev-dependencies]
 const-cstr = "0.3"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -187,6 +187,10 @@ fn build_rocksdb() {
 
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
 
+    if cfg!(feature = "jemalloc") {
+        config.define("WITH_JEMALLOC", "ON");
+    }
+
     if target.contains("msvc") {
         config.flag("-EHsc");
     } else {


### PR DESCRIPTION
RocksDB includes some optimizations when it's compiled with jemalloc. This PR allows enabling jemalloc using new `jemalloc` feature. 