### PR TITLE
add feature flag for runtime type information, and metadata for locating library and sources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lz4 = ["librocksdb-sys/lz4"]
 zstd = ["librocksdb-sys/zstd"]
 zlib = ["librocksdb-sys/zlib"]
 bzip2 = ["librocksdb-sys/bzip2"]
+rtti = ["librocksdb-sys/rtti"]
 multi-threaded-cf = []
 
 [dependencies]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -19,6 +19,7 @@ lz4 = []
 zstd = []
 zlib = []
 bzip2 = []
+rtti = []
 
 [dependencies]
 libc = "0.2"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -399,4 +399,13 @@ fn main() {
         fail_on_empty_directory("bzip2");
         build_bzip2();
     }
+
+    // Allow dependent crates to locate the sources and output directory of
+    // this crate. Notably, this allows a dependent crate to locate the RocksDB
+    // sources and built archive artifacts provided by this crate.
+    println!(
+        "cargo:cargo_manifest_dir={}",
+        env::var("CARGO_MANIFEST_DIR").unwrap()
+    );
+    println!("cargo:out_dir={}", env::var("OUT_DIR").unwrap());
 }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -83,6 +83,10 @@ fn build_rocksdb() {
         config.include("bzip2/");
     }
 
+    if cfg!(feature = "rtti") {
+        config.define("USE_RTTI", Some("1"));
+    }
+
     config.include(".");
     config.define("NDEBUG", Some("1"));
 


### PR DESCRIPTION
We have an advanced use case with [Estuary Flow](github.com/estuary/flow) where we're interoperating Go and Rust within a single process, and wish to use this crate to actually build RocksDB, while linking it using the `go` toolchain.

We've gotten this working by having the `librocksdb-sys` crate publish metadata which dependent crates can utilize to locate the RocksDB include sources and the libraries built by this crate.

Our use case also requires the RTTI compile-time flag of RocksDB, which is disabled by default. I've added this as a feature flag.