### PR TITLE
Add tilde to librocksdb-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ multi-threaded-cf = []
 
 [dependencies]
 libc = "0.2"
-librocksdb-sys = { path = "librocksdb-sys", version = "6.20.3" }
+librocksdb-sys = { path = "librocksdb-sys", version = "~6.20.3" }
 
 [dev-dependencies]
 trybuild = "1.0"


### PR DESCRIPTION
I am using rust-rocksdb 0.15 which I believe it uses sys 6.11.4 but it is actually 6.20.3 which is the latest. The build started to fail because it requires newer clang. Compiling newer librocksdb-sys often requires environmental update. This is not convenient for users.

```
error: failed to run custom build command for `librocksdb-sys v6.20.3`

Caused by:
  process didn't exit successfully: `/lol-root/target/release/build/librocksdb-sys-92df1d9f70841902/build-script-build` (exit code: 101)
  --- stderr
  rocksdb/include/rocksdb/c.h:45:9: warning: #pragma once in main file, err: false
  thread 'main' panicked at '`libclang` function not loaded: `clang_Type_getNumTemplateArguments`. This crate requires that `libclang` 3.9 or later be installed on your system. For more information on how to accomplish this, see here: https://rust-lang.github.io/rust-bindgen/requirements.html#installing-clang-39', /home/akira.hayakawa/.cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-1.2.0/src/lib.rs:1682:1
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: failed to compile `kvs v0.1.0 (/lol-root/kvs)`, intermediate artifacts can be found at `/lol-root/target`
```

Here is a result of cargo-tree:
```
│   │   ├── rocksdb v0.15.0
│   │   │   ├── libc v0.2.99
│   │   │   └── librocksdb-sys v6.20.3
```

The reason is version 6.11.4 is interpreted as ^6.11.4 which may try to use 6.11.4 .. 7.0.0. 

I want it to be narrower by adding `~`. The effect of this is that it chooses the latest version between 6.11.4 .. 6.12.0. (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements)

For the older version, I will give up and I will update the OS for newer clang. But I don't want this happen again.
