### PR TITLE
Support UTF-8 file paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+* Re-add support for UTF-8 file paths on Windows (rajivshah3)
 
 ## 0.17.0 (2021-07-22)
 

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -152,6 +152,7 @@ fn build_rocksdb() {
         config.define("_MBCS", None);
         config.define("WIN64", None);
         config.define("NOMINMAX", None);
+        config.define("WITH_WINDOWS_UTF8_FILENAMES", "ON");
 
         if &target == "x86_64-pc-windows-gnu" {
             // Tell MinGW to create localtime_r wrapper of localtime_s function.


### PR DESCRIPTION
This re-adds support for UTF-8 file paths on Windows, which was removed in #493 

Fixes #512 
Fixes #85 (already closed)