### PR TITLE
Add merge operands iterator

### DIFF
--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -20,10 +20,10 @@
 //!
 //! fn concat_merge(new_key: &[u8],
 //!                 existing_val: Option<&[u8]>,
-//!                 operands: &mut MergeOperands)
+//!                 operands: &MergeOperands)
 //!                 -> Option<Vec<u8>> {
 //!
-//!    let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
+//!    let mut result: Vec<u8> = Vec::with_capacity(operands.len());
 //!    existing_val.map(|v| {
 //!        for e in v {
 //!            result.push(*e)

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -194,7 +194,7 @@ fn test_provided_merge(
     existing_val: Option<&[u8]>,
     operands: &mut MergeOperands,
 ) -> Option<Vec<u8>> {
-    let nops = operands.size_hint().0;
+    let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);
     if let Some(v) = existing_val {
         for e in v {

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -192,7 +192,7 @@ fn test_merge_operator() {
 fn test_provided_merge(
     _: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);

--- a/tests/test_merge_operator.rs
+++ b/tests/test_merge_operator.rs
@@ -24,7 +24,7 @@ fn test_provided_merge(
     existing_val: Option<&[u8]>,
     operands: &mut MergeOperands,
 ) -> Option<Vec<u8>> {
-    let nops = operands.size_hint().0;
+    let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);
     if let Some(v) = existing_val {
         for e in v {
@@ -99,7 +99,7 @@ fn test_counting_partial_merge(
     _existing_val: Option<&[u8]>,
     operands: &mut MergeOperands,
 ) -> Option<Vec<u8>> {
-    let nops = operands.size_hint().0;
+    let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);
     for op in operands {
         for e in op {

--- a/tests/test_merge_operator.rs
+++ b/tests/test_merge_operator.rs
@@ -22,7 +22,7 @@ use util::DBPath;
 fn test_provided_merge(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);
@@ -97,7 +97,7 @@ impl ValueCounts {
 fn test_counting_partial_merge(
     _new_key: &[u8],
     _existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     let nops = operands.len();
     let mut result: Vec<u8> = Vec::with_capacity(nops);
@@ -112,7 +112,7 @@ fn test_counting_partial_merge(
 fn test_counting_full_merge(
     _new_key: &[u8],
     existing_val: Option<&[u8]>,
-    operands: &mut MergeOperands,
+    operands: &MergeOperands,
 ) -> Option<Vec<u8>> {
     let mut counts = existing_val
         .map(|v| ValueCounts::from_slice(v))
@@ -251,7 +251,7 @@ fn failed_merge_test() {
     fn test_failing_merge(
         _key: &[u8],
         _val: Option<&[u8]>,
-        _operands: &mut MergeOperands,
+        _operands: &MergeOperands,
     ) -> Option<Vec<u8>> {
         None
     }
@@ -274,7 +274,7 @@ fn failed_merge_test() {
 }
 
 fn make_merge_max_with_limit(limit: u64) -> impl MergeFn + Clone {
-    move |_key: &[u8], first: Option<&[u8]>, rest: &mut MergeOperands| {
+    move |_key: &[u8], first: Option<&[u8]>, rest: &MergeOperands| {
         let max = first
             .into_iter()
             .chain(rest)


### PR DESCRIPTION
Rework merge operands iterator. 
`&mut` is not needed, so you can iterate several times over the iterator.
In our specific use case, it gave speedup up to 80% due to lack of realocations.