### PR TITLE
Support restoring from a specified backup

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -170,6 +170,55 @@ impl BackupEngine {
         Ok(())
     }
 
+    /// Restore from a specified backup
+    ///
+    /// # Arguments
+    ///
+    /// * `db_dir` - A path to the database directory
+    /// * `wal_dir` - A path to the wal directory
+    /// * `opts` - Restore options
+    /// * `backup_id` - The backup id to restore
+    pub fn restore_from_backup<D: AsRef<Path>, W: AsRef<Path>>(
+        &mut self,
+        db_dir: D,
+        wal_dir: W,
+        opts: &RestoreOptions,
+        backup_id: u32,
+    ) -> Result<(), Error> {
+        let db_dir = db_dir.as_ref();
+        let c_db_dir = if let Ok(c) = CString::new(db_dir.to_string_lossy().as_bytes()) {
+            c
+        } else {
+            return Err(Error::new(
+                "Failed to convert db_dir to CString \
+                     when restoring from latest backup"
+                    .to_owned(),
+            ));
+        };
+
+        let wal_dir = wal_dir.as_ref();
+        let c_wal_dir = if let Ok(c) = CString::new(wal_dir.to_string_lossy().as_bytes()) {
+            c
+        } else {
+            return Err(Error::new(
+                "Failed to convert wal_dir to CString \
+                     when restoring from latest backup"
+                    .to_owned(),
+            ));
+        };
+
+        unsafe {
+            ffi_try!(ffi::rocksdb_backup_engine_restore_db_from_backup(
+                self.inner,
+                c_db_dir.as_ptr(),
+                c_wal_dir.as_ptr(),
+                opts.inner,
+                backup_id,
+            ));
+        }
+        Ok(())
+    }
+
     /// Checks that each file exists and that the size of the file matches our
     /// expectations. it does not check file checksum.
     ///

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -172,12 +172,7 @@ impl BackupEngine {
 
     /// Restore from a specified backup
     ///
-    /// # Arguments
-    ///
-    /// * `db_dir` - A path to the database directory
-    /// * `wal_dir` - A path to the wal directory
-    /// * `opts` - Restore options
-    /// * `backup_id` - The backup id to restore
+    /// The specified backup id should be passed in as an additional parameter.
     pub fn restore_from_backup<D: AsRef<Path>, W: AsRef<Path>>(
         &mut self,
         db_dir: D,

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -23,75 +23,83 @@ use rocksdb::{
 use util::DBPath;
 
 #[test]
-fn backup_restore() {
+fn restore_from_latest() {
     // create backup
-    let path = DBPath::new("backup_test");
-    let restore_path_1 = DBPath::new("restore_from_backup_path_1");
-    let restore_path_2 = DBPath::new("restore_from_backup_path_2");
+    let path = DBPath::new("restore_from_latest_test");
+    let restore_path = DBPath::new("restore_from_latest_path");
     {
         let db = DB::open_default(&path).unwrap();
         assert!(db.put(b"k1", b"v1111").is_ok());
         let value = db.get(b"k1");
         assert_eq!(value.unwrap().unwrap(), b"v1111");
-        assert!(db.put(b"k2", b"v2222").is_ok());
-        let value = db.get(b"k2");
-        assert_eq!(value.unwrap().unwrap(), b"v2222");
         {
-            let backup_path = DBPath::new("backup_path");
+            let backup_path = DBPath::new("backup_path_1");
             let backup_opts = BackupEngineOptions::default();
             let mut backup_engine = BackupEngine::open(&backup_opts, &backup_path).unwrap();
-
-            // create first backup
-            assert!(backup_engine.create_new_backup(&db).is_ok());
-
-            // delete "k2" and create second backup
-            assert!(db.delete(b"k2").is_ok());
             assert!(backup_engine.create_new_backup(&db).is_ok());
 
             // check backup info
             let info = backup_engine.get_backup_info();
-            assert_eq!(info.len(), 2);
+            assert!(!info.is_empty());
             info.iter().for_each(|i| {
                 assert!(backup_engine.verify_backup(i.backup_id).is_ok());
                 assert!(i.size > 0);
             });
 
-            {
-                // restore the first backup
-                let backup_1_id = info.get(0).unwrap().backup_id;
-                let mut restore_option = RestoreOptions::default();
-                restore_option.set_keep_log_files(false); // true to keep log files
-                let restore_status = backup_engine.restore_from_backup(
-                    &restore_path_1,
-                    &restore_path_1,
-                    &restore_option,
-                    backup_1_id,
-                );
-                assert!(restore_status.is_ok());
+            let mut restore_option = RestoreOptions::default();
+            restore_option.set_keep_log_files(false); // true to keep log files
+            let restore_status = backup_engine.restore_from_latest_backup(
+                &restore_path,
+                &restore_path,
+                &restore_option,
+            );
+            assert!(restore_status.is_ok());
 
-                let db_restore = DB::open_default(&restore_path_1).unwrap();
-                let value = db_restore.get(b"k1");
-                assert_eq!(value.unwrap().unwrap(), b"v1111");
-                let value = db_restore.get(b"k2");
-                assert_eq!(value.unwrap().unwrap(), b"v2222");
-            }
-            {
-                // restore the second(latest) backup
-                let mut restore_option = RestoreOptions::default();
-                restore_option.set_keep_log_files(false); // true to keep log files
-                let restore_status = backup_engine.restore_from_latest_backup(
-                    &restore_path_2,
-                    &restore_path_2,
-                    &restore_option,
-                );
-                assert!(restore_status.is_ok());
+            let db_restore = DB::open_default(&restore_path).unwrap();
+            let value = db_restore.get(b"k1");
+            assert_eq!(value.unwrap().unwrap(), b"v1111");
+        }
+    }
+}
 
-                let db_restore = DB::open_default(&restore_path_2).unwrap();
-                let value = db_restore.get(b"k1");
-                assert_eq!(value.unwrap().unwrap(), b"v1111");
-                let value = db_restore.get(b"k2");
-                assert!(value.unwrap().is_none());
-            }
+#[test]
+fn restore_from_backup() {
+    // create backup
+    let path = DBPath::new("restore_from_backup_test");
+    let restore_path = DBPath::new("restore_from_backup_path");
+    {
+        let db = DB::open_default(&path).unwrap();
+        assert!(db.put(b"k1", b"v1111").is_ok());
+        let value = db.get(b"k1");
+        assert_eq!(value.unwrap().unwrap(), b"v1111");
+        {
+            let backup_path = DBPath::new("backup_path_2");
+            let backup_opts = BackupEngineOptions::default();
+            let mut backup_engine = BackupEngine::open(&backup_opts, &backup_path).unwrap();
+            assert!(backup_engine.create_new_backup(&db).is_ok());
+
+            // check backup info
+            let info = backup_engine.get_backup_info();
+            assert!(!info.is_empty());
+            info.iter().for_each(|i| {
+                assert!(backup_engine.verify_backup(i.backup_id).is_ok());
+                assert!(i.size > 0);
+            });
+
+            let backup_id = info.get(0).unwrap().backup_id;
+            let mut restore_option = RestoreOptions::default();
+            restore_option.set_keep_log_files(false); // true to keep log files
+            let restore_status = backup_engine.restore_from_backup(
+                &restore_path,
+                &restore_path,
+                &restore_option,
+                backup_id,
+            );
+            assert!(restore_status.is_ok());
+
+            let db_restore = DB::open_default(&restore_path).unwrap();
+            let value = db_restore.get(b"k1");
+            assert_eq!(value.unwrap().unwrap(), b"v1111");
         }
     }
 }

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -26,38 +26,72 @@ use util::DBPath;
 fn backup_restore() {
     // create backup
     let path = DBPath::new("backup_test");
-    let restore_path = DBPath::new("restore_from_backup_path");
+    let restore_path_1 = DBPath::new("restore_from_backup_path_1");
+    let restore_path_2 = DBPath::new("restore_from_backup_path_2");
     {
         let db = DB::open_default(&path).unwrap();
         assert!(db.put(b"k1", b"v1111").is_ok());
         let value = db.get(b"k1");
         assert_eq!(value.unwrap().unwrap(), b"v1111");
+        assert!(db.put(b"k2", b"v2222").is_ok());
+        let value = db.get(b"k2");
+        assert_eq!(value.unwrap().unwrap(), b"v2222");
         {
             let backup_path = DBPath::new("backup_path");
             let backup_opts = BackupEngineOptions::default();
             let mut backup_engine = BackupEngine::open(&backup_opts, &backup_path).unwrap();
+
+            // create first backup
+            assert!(backup_engine.create_new_backup(&db).is_ok());
+
+            // delete "k2" and create second backup
+            assert!(db.delete(b"k2").is_ok());
             assert!(backup_engine.create_new_backup(&db).is_ok());
 
             // check backup info
             let info = backup_engine.get_backup_info();
-            assert!(!info.is_empty());
+            assert_eq!(info.len(), 2);
             info.iter().for_each(|i| {
                 assert!(backup_engine.verify_backup(i.backup_id).is_ok());
                 assert!(i.size > 0);
             });
 
-            let mut restore_option = RestoreOptions::default();
-            restore_option.set_keep_log_files(false); // true to keep log files
-            let restore_status = backup_engine.restore_from_latest_backup(
-                &restore_path,
-                &restore_path,
-                &restore_option,
-            );
-            assert!(restore_status.is_ok());
+            {
+                // restore the first backup
+                let backup_1_id = info.get(0).unwrap().backup_id;
+                let mut restore_option = RestoreOptions::default();
+                restore_option.set_keep_log_files(false); // true to keep log files
+                let restore_status = backup_engine.restore_from_backup(
+                    &restore_path_1,
+                    &restore_path_1,
+                    &restore_option,
+                    backup_1_id,
+                );
+                assert!(restore_status.is_ok());
 
-            let db_restore = DB::open_default(&restore_path).unwrap();
-            let value = db_restore.get(b"k1");
-            assert_eq!(value.unwrap().unwrap(), b"v1111");
+                let db_restore = DB::open_default(&restore_path_1).unwrap();
+                let value = db_restore.get(b"k1");
+                assert_eq!(value.unwrap().unwrap(), b"v1111");
+                let value = db_restore.get(b"k2");
+                assert_eq!(value.unwrap().unwrap(), b"v2222");
+            }
+            {
+                // restore the second(latest) backup
+                let mut restore_option = RestoreOptions::default();
+                restore_option.set_keep_log_files(false); // true to keep log files
+                let restore_status = backup_engine.restore_from_latest_backup(
+                    &restore_path_2,
+                    &restore_path_2,
+                    &restore_option,
+                );
+                assert!(restore_status.is_ok());
+
+                let db_restore = DB::open_default(&restore_path_2).unwrap();
+                let value = db_restore.get(b"k1");
+                assert_eq!(value.unwrap().unwrap(), b"v1111");
+                let value = db_restore.get(b"k2");
+                assert!(value.unwrap().is_none());
+            }
         }
     }
 }


### PR DESCRIPTION
The current BackupEngine in src/backup.rs can only restore from the latest (`fn restore_from_latest_backup()`) and miss a method to restore from a specified backup id. As we can see, the rocksdb ffi `rocksdb_backup_engine_restore_db_from_backup` is provided in librocksdb-sys.

This pull request makes it to support restoring from a specified backup.

Related to issue #560 