### PR TITLE
Open DB with read-only access and with column family descriptors

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -327,6 +327,7 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
             },
         )
     }
+
     /// Opens a database for read only with the given database options and column family names.
     pub fn open_cf_for_read_only<P, I, N>(
         opts: &Options,

--- a/src/db.rs
+++ b/src/db.rs
@@ -307,6 +307,26 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
         Self::open_cf_descriptors_internal(opts, path, cfs, &AccessType::ReadWrite)
     }
 
+    /// Opens a read-only database with the given database options and column family descriptors.
+    pub fn open_cf_descriptors_read_only<P, I>(
+        opts: &Options,
+        path: P,
+        cfs: I,
+        error_if_log_file_exist: bool,
+    ) -> Result<Self, Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        Self::open_cf_descriptors_internal(
+            opts,
+            path,
+            cfs,
+            &AccessType::ReadOnly {
+                error_if_log_file_exist,
+            },
+        )
+    }
     /// Opens a database for read only with the given database options and column family names.
     pub fn open_cf_for_read_only<P, I, N>(
         opts: &Options,


### PR DESCRIPTION
This pull request is motivated by https://github.com/near/nearcore/issues/5194
In short, I want to ensure that a debug-only tool accesses RocksDB strictly read-only.
It has happened already that a newer version of the debug-only tool made changes to the DB. Unfortunately, that meant that the original binary was no longer able to use that DB, and the DB had to be recovered from a backup.