### PR TITLE
Optimize non-overlapping copy in raw_data

### DIFF
--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -29,8 +29,8 @@ pub(crate) unsafe fn raw_data(ptr: *const c_char, size: usize) -> Option<Vec<u8>
         None
     } else {
         let mut dst = Vec::with_capacity(size);
+        ptr::copy_nonoverlapping(ptr as *const u8, dst.as_mut_ptr(), size);
         dst.set_len(size);
-        ptr::copy(ptr as *const u8, dst.as_mut_ptr(), size);
         Some(dst)
     }
 }


### PR DESCRIPTION
A newly allocated vector cannot overlap with the source, so the copy can be optimized slightly. Also [reordered](https://rust-lang.github.io/rust-clippy/master/index.html#uninit_vec) the copy and `set_len()`.