### PR TITLE
Replace mem::transmute with narrower conversions

### DIFF
--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -30,7 +30,6 @@ use std::borrow::Cow;
 use std::env;
 use std::ffi::{CStr, CString};
 use std::io::Write;
-use std::mem;
 use std::path::PathBuf;
 use std::ptr;
 use std::slice;
@@ -284,15 +283,15 @@ unsafe extern "C" fn CFilterFilter(
 ) -> c_uchar {
     if key_length == 3 {
         if memcmp(
-            mem::transmute(key),
-            mem::transmute(cstrp!("bar")),
+            key.cast::<c_void>(),
+            cstrp!("bar").cast::<c_void>(),
             key_length,
         ) == 0
         {
             return 1;
         } else if memcmp(
-            mem::transmute(key),
-            mem::transmute(cstrp!("baz")),
+            key.cast::<c_void>(),
+            cstrp!("baz").cast::<c_void>(),
             key_length,
         ) == 0
         {
@@ -474,10 +473,10 @@ fn ffi() {
         rocksdb_block_based_options_set_block_cache(table_options, cache);
         rocksdb_options_set_block_based_table_factory(options, table_options);
 
-        let no_compression = rocksdb_no_compression;
-        rocksdb_options_set_compression(options, no_compression as i32);
+        let no_compression = rocksdb_no_compression as c_int;
+        rocksdb_options_set_compression(options, no_compression);
         rocksdb_options_set_compression_options(options, -14, -1, 0, 0);
-        let compression_levels = vec![
+        let mut compression_levels = vec![
             no_compression,
             no_compression,
             no_compression,
@@ -485,7 +484,7 @@ fn ffi() {
         ];
         rocksdb_options_set_compression_per_level(
             options,
-            mem::transmute(compression_levels.as_ptr()),
+            compression_levels.as_mut_ptr(),
             compression_levels.len() as size_t,
         );
 
@@ -601,7 +600,7 @@ fn ffi() {
             let mut pos: c_int = 0;
             rocksdb_writebatch_iterate(
                 wb,
-                mem::transmute(&mut pos),
+                (&mut pos as *mut c_int).cast::<c_void>(),
                 Some(CheckPut),
                 Some(CheckDel),
             );

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::ffi::{CStr, CString};
-use std::mem;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -1137,7 +1136,7 @@ impl Options {
 
         unsafe {
             let mo = ffi::rocksdb_mergeoperator_create(
-                Box::into_raw(cb) as _,
+                Box::into_raw(cb).cast::<c_void>(),
                 Some(merge_operator::destructor_callback::<F, F>),
                 Some(full_merge_callback::<F, F>),
                 Some(partial_merge_callback::<F, F>),
@@ -1162,7 +1161,7 @@ impl Options {
 
         unsafe {
             let mo = ffi::rocksdb_mergeoperator_create(
-                Box::into_raw(cb) as _,
+                Box::into_raw(cb).cast::<c_void>(),
                 Some(merge_operator::destructor_callback::<F, PF>),
                 Some(full_merge_callback::<F, PF>),
                 Some(partial_merge_callback::<F, PF>),
@@ -1202,7 +1201,7 @@ impl Options {
 
         unsafe {
             let cf = ffi::rocksdb_compactionfilter_create(
-                mem::transmute(cb),
+                Box::into_raw(cb).cast::<c_void>(),
                 Some(compaction_filter::destructor_callback::<CompactionFilterCallback<F>>),
                 Some(compaction_filter::filter_callback::<CompactionFilterCallback<F>>),
                 Some(compaction_filter::name_callback::<CompactionFilterCallback<F>>),
@@ -1227,7 +1226,7 @@ impl Options {
 
         unsafe {
             let cff = ffi::rocksdb_compactionfilterfactory_create(
-                Box::into_raw(factory) as *mut c_void,
+                Box::into_raw(factory).cast::<c_void>(),
                 Some(compaction_filter_factory::destructor_callback::<F>),
                 Some(compaction_filter_factory::create_compaction_filter_callback::<F>),
                 Some(compaction_filter_factory::name_callback::<F>),
@@ -1251,7 +1250,7 @@ impl Options {
 
         unsafe {
             let cmp = ffi::rocksdb_comparator_create(
-                mem::transmute(cb),
+                Box::into_raw(cb).cast::<c_void>(),
                 Some(comparator::destructor_callback),
                 Some(comparator::compare_callback),
                 Some(comparator::name_callback),

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -211,10 +211,10 @@ impl MergeOperands {
                 let len_ptr = (base_len + (spacing_len * index)) as *const size_t;
                 let len = *len_ptr as usize;
                 let ptr = base + (spacing * index);
-                Some(mem::transmute(slice::from_raw_parts(
+                Some(slice::from_raw_parts(
                     *(ptr as *const *const u8) as *const u8,
                     len,
-                )))
+                ))
             }
         }
     }


### PR DESCRIPTION
Using more specific conversions is preferable, where possible.