### PR TITLE
Fix theoretical UB while transmuting Arc

### DIFF
--- a/src/column_family.rs
+++ b/src/column_family.rs
@@ -71,7 +71,7 @@ impl UnboundColumnFamily {
     pub(crate) fn bound_column_family<'a>(self: Arc<Self>) -> Arc<BoundColumnFamily<'a>> {
         // SAFETY: the new BoundColumnFamily here just adding lifetime,
         // so that column family handle won't outlive db.
-        unsafe { std::mem::transmute(self) }
+        unsafe { Arc::from_raw(Arc::into_raw(self).cast()) }
     }
 }
 


### PR DESCRIPTION
As far as I can tell, there is no guarantee that `Arc<T>` can be soundly transmuted to `Arc<U>`, even if `T` can be soundly transmuted to `U`.

Looking at the implementation of `Arc`, it is effectively a single field struct, wrapping a private `NonNull<ArcInner<T>>` where `ArcInner<T>` is `#[repr(C)]`, so the transmute is not UB as of now, and of course it's unlikely that this would change. But it's still not good to rely on such an implementation detail for soundness.