### PR TITLE
Update RocksDB to v6.29.0

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librocksdb-sys"
-version = "6.20.3"
+version = "6.29.0"
 edition = "2018"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"

--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -7,9 +7,9 @@
 
 // The build script may replace these values with real values based
 // on whether or not GIT is available and the platform settings
-static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:51b540921dd7495c9cf2265eb58942dad1f2ef72";
-static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v6.22.1";
-static const std::string rocksdb_build_date = "rocksdb_build_date:2021-06-25 14:15:04";
+static const std::string rocksdb_build_git_sha  = "rocksdb_build_git_sha:e8f116deabc601a5eae011f2fd8a38d02d87be8d";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:6.29.fb";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2022-01-21 17:23:03";
 
 namespace ROCKSDB_NAMESPACE {
 static void AddProperty(std::unordered_map<std::string, std::string> *props, const std::string& name) {

--- a/librocksdb-sys/rocksdb_lib_sources.txt
+++ b/librocksdb-sys/rocksdb_lib_sources.txt
@@ -1,5 +1,7 @@
 cache/cache.cc
 cache/cache_entry_roles.cc
+cache/cache_key.cc
+cache/cache_reservation_manager.cc
 cache/clock_cache.cc
 cache/lru_cache.cc
 cache/sharded_cache.cc
@@ -11,9 +13,11 @@ db/blob/blob_file_cache.cc
 db/blob/blob_file_garbage.cc
 db/blob/blob_file_meta.cc
 db/blob/blob_file_reader.cc
+db/blob/blob_garbage_meter.cc
 db/blob/blob_log_format.cc
 db/blob/blob_log_sequential_reader.cc
 db/blob/blob_log_writer.cc
+db/blob/prefetch_buffer_collection.cc
 db/builder.cc
 db/c.cc
 db/column_family.cc
@@ -90,6 +94,7 @@ env/fs_remap.cc
 env/file_system_tracer.cc
 env/io_posix.cc
 env/mock_env.cc
+env/unique_id_gen.cc
 file/delete_scheduler.cc
 file/file_prefetch_buffer.cc
 file/file_util.cc
@@ -108,6 +113,7 @@ memory/arena.cc
 memory/concurrent_arena.cc
 memory/jemalloc_nodump_allocator.cc
 memory/memkind_kmem_allocator.cc
+memory/memory_allocator.cc
 memtable/alloc_tracker.cc
 memtable/hash_linklist_rep.cc
 memtable/hash_skiplist_rep.cc
@@ -185,10 +191,14 @@ table/sst_file_writer.cc
 table/table_factory.cc
 table/table_properties.cc
 table/two_level_iterator.cc
+table/unique_id.cc
 test_util/sync_point.cc
 test_util/sync_point_impl.cc
 test_util/transaction_test_util.cc
 tools/dump/db_dump_tool.cc
+trace_replay/trace_record_handler.cc
+trace_replay/trace_record_result.cc
+trace_replay/trace_record.cc
 trace_replay/trace_replay.cc
 trace_replay/block_cache_tracer.cc
 trace_replay/io_tracer.cc
@@ -199,12 +209,14 @@ util/comparator.cc
 util/compression_context_cache.cc
 util/concurrent_task_limiter_impl.cc
 util/crc32c.cc
+util/crc32c_arm64.cc
 util/dynamic_bloom.cc
 util/hash.cc
 util/murmurhash.cc
 util/random.cc
 util/rate_limiter.cc
 util/ribbon_config.cc
+util/regex.cc
 util/slice.cc
 util/file_checksum_helper.cc
 util/status.cc
@@ -218,10 +230,13 @@ utilities/blob_db/blob_db.cc
 utilities/blob_db/blob_db_impl.cc
 utilities/blob_db/blob_db_impl_filesnapshot.cc
 utilities/blob_db/blob_file.cc
+utilities/cache_dump_load.cc
+utilities/cache_dump_load_impl.cc
 utilities/cassandra/cassandra_compaction_filter.cc
 utilities/cassandra/format.cc
 utilities/cassandra/merge_operator.cc
 utilities/checkpoint/checkpoint_impl.cc
+utilities/compaction_filters.cc
 utilities/compaction_filters/remove_emptyvalue_compactionfilter.cc
 utilities/convenience/info_log_finder.cc
 utilities/debug.cc
@@ -229,8 +244,10 @@ utilities/env_mirror.cc
 utilities/env_timed.cc
 utilities/fault_injection_env.cc
 utilities/fault_injection_fs.cc
+utilities/fault_injection_secondary_cache.cc
 utilities/leveldb_options/leveldb_options.cc
 utilities/memory/memory_util.cc
+utilities/merge_operators.cc
 utilities/merge_operators/max.cc
 utilities/merge_operators/put.cc
 utilities/merge_operators/sortlist.cc
@@ -250,6 +267,7 @@ utilities/simulator_cache/cache_simulator.cc
 utilities/simulator_cache/sim_cache.cc
 utilities/table_properties_collectors/compact_on_deletion_collector.cc
 utilities/trace/file_trace_reader_writer.cc
+utilities/trace/replayer_impl.cc
 utilities/transactions/lock/lock_manager.cc
 utilities/transactions/lock/point/point_lock_tracker.cc
 utilities/transactions/lock/point/point_lock_manager.cc
@@ -266,5 +284,6 @@ utilities/transactions/write_prepared_txn_db.cc
 utilities/transactions/write_unprepared_txn.cc
 utilities/transactions/write_unprepared_txn_db.cc
 utilities/ttl/db_ttl_impl.cc
+utilities/wal_filter.cc
 utilities/write_batch_with_index/write_batch_with_index.cc
 utilities/write_batch_with_index/write_batch_with_index_internal.cc

--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -476,7 +476,7 @@ fn ffi() {
         let no_compression = rocksdb_no_compression as c_int;
         rocksdb_options_set_compression(options, no_compression);
         rocksdb_options_set_compression_options(options, -14, -1, 0, 0);
-        let mut compression_levels = vec![
+        let compression_levels = vec![
             no_compression,
             no_compression,
             no_compression,
@@ -484,7 +484,7 @@ fn ffi() {
         ];
         rocksdb_options_set_compression_per_level(
             options,
-            compression_levels.as_mut_ptr(),
+            compression_levels.as_ptr(),
             compression_levels.len() as size_t,
         );
 
@@ -802,7 +802,7 @@ fn ffi() {
                     Some(FilterName),
                 )
             } else {
-                rocksdb_filterpolicy_create_bloom(10)
+                rocksdb_filterpolicy_create_bloom(10.0)
             };
 
             rocksdb_block_based_options_set_filter_policy(table_options, policy);

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -16,7 +16,7 @@ use std::ffi::{CStr, CString};
 use std::path::Path;
 use std::sync::Arc;
 
-use libc::{self, c_char, c_int, c_uchar, c_uint, c_void, size_t};
+use libc::{self, c_char, c_double, c_int, c_uchar, c_uint, c_void, size_t};
 
 use crate::{
     compaction_filter::{self, CompactionFilterCallback, CompactionFilterFn},
@@ -562,7 +562,7 @@ impl BlockBasedOptions {
     }
 
     /// Sets the filter policy to reduce disk reads
-    pub fn set_bloom_filter(&mut self, bits_per_key: c_int, block_based: bool) {
+    pub fn set_bloom_filter(&mut self, bits_per_key: c_double, block_based: bool) {
         unsafe {
             let bloom = if block_based {
                 ffi::rocksdb_filterpolicy_create_bloom(bits_per_key)
@@ -1029,11 +1029,11 @@ impl Options {
     /// ]);
     /// ```
     pub fn set_compression_per_level(&mut self, level_types: &[DBCompressionType]) {
+        let level_types: Vec<_> = level_types.iter().map(|&t| t as c_int).collect();
         unsafe {
-            let mut level_types: Vec<_> = level_types.iter().map(|&t| t as c_int).collect();
             ffi::rocksdb_options_set_compression_per_level(
                 self.inner,
-                level_types.as_mut_ptr(),
+                level_types.as_ptr(),
                 level_types.len() as size_t,
             );
         }


### PR DESCRIPTION
For bugfixes and new features. The following required further changes in this library:

* From 6.29.0:

  > Take compression level_values as const pointer 

* From 6.24.0:

  > Generalized bits_per_key parameters in C API from int to double for greater configurability. Although this is a compatible change for existing C source code, anything depending on C API signatures, such as foreign function interfaces, will need to be updated.