### PR TITLE
fixup! Add constants for all supported properties (#589)

### DIFF
--- a/src/properties.rs
+++ b/src/properties.rs
@@ -19,7 +19,7 @@ pub const NUM_FILES_AT_LEVEL_PREFIX: &str = property!("num-files-at-level");
 /// representation of a level number (e.g., "0"). Here, compression
 /// ratio is defined as uncompressed data size / compressed file size.
 /// Returns "-1.0" if no open files at level <N>.
-pub const COMPRESSION_RATIO_AT_LEVEL: &str = property!("rocksdb.compression-ratio-at-level");
+pub const COMPRESSION_RATIO_AT_LEVEL: &str = property!("compression-ratio-at-level");
 
 /// "rocksdb.stats" - returns a multi-line string containing the data
 /// described by kCFStats followed by the data described by kDBStats.


### PR DESCRIPTION
Fixing a typo from https://github.com/rust-rocksdb/rust-rocksdb/pull/589 that added extra prefix to one of the property strings (thus making it invalid) - kudos to @niklasf for [catching the mistake](https://github.com/rust-rocksdb/rust-rocksdb/commit/daee3d636c575fef60d93e448a8e1078afd7c041#r65861692).