### PR TITLE
Point librocksdb-sys to the correct version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde1 = ["serde"]
 
 [dependencies]
 libc = "0.2"
-librocksdb-sys = { path = "librocksdb-sys", version = "6.20.3" }
+librocksdb-sys = { path = "librocksdb-sys", version = "6.28.2" }
 serde = { version = "1", features = [ "derive" ], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
https://github.com/rust-rocksdb/rust-rocksdb/pull/600 updated `librocksdb-sys` but didn't update the dependency in the main crate.