### PR TITLE
fix: 'bz_internal_error': symbol multiply defined!

### DIFF
--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -26,9 +26,3 @@ extern crate libz_sys;
 extern crate zstd_sys;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
-
-#[cfg(feature = "bzip2")]
-#[no_mangle]
-pub fn bz_internal_error(errcode: libc::c_int) {
-    panic!("bz internal error: {}", errcode);
-}


### PR DESCRIPTION
Fix: https://github.com/rust-rocksdb/rust-rocksdb/issues/609

The `bz_internal_error` was introduced when  [bzip2 support was added](https://github.com/rust-rocksdb/rust-rocksdb/pull/209), the bzip2-sys crate was not used at that time.
This function should be removed after [using bzip2-sys crate](https://github.com/rust-rocksdb/rust-rocksdb/pull/555), otherwise it will conflict with the definition in bzip2-sys when compiled with lto enabled.