### PR TITLE
Add `DBRawIteratorWithThreadMode::item` method returning (key, value)

### DIFF
--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -297,13 +297,7 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         if self.valid() {
             // Safety Note: This is safe as all methods that may invalidate the buffer returned
             // take `&mut self`, so borrow checker will prevent use of buffer after seek.
-            unsafe {
-                let mut key_len: size_t = 0;
-                let key_len_ptr: *mut size_t = &mut key_len;
-                let key_ptr = ffi::rocksdb_iter_key(self.inner, key_len_ptr) as *const c_uchar;
-
-                Some(slice::from_raw_parts(key_ptr, key_len as usize))
-            }
+            Some(self.key_impl())
         } else {
             None
         }
@@ -314,15 +308,44 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         if self.valid() {
             // Safety Note: This is safe as all methods that may invalidate the buffer returned
             // take `&mut self`, so borrow checker will prevent use of buffer after seek.
-            unsafe {
-                let mut val_len: size_t = 0;
-                let val_len_ptr: *mut size_t = &mut val_len;
-                let val_ptr = ffi::rocksdb_iter_value(self.inner, val_len_ptr) as *const c_uchar;
-
-                Some(slice::from_raw_parts(val_ptr, val_len as usize))
-            }
+            Some(self.value_impl())
         } else {
             None
+        }
+    }
+
+    /// Returns pair with slice of the current key and current value.
+    pub fn item(&self) -> Option<(&[u8], &[u8])> {
+        if self.valid() {
+            // Safety Note: This is safe as all methods that may invalidate the buffer returned
+            // take `&mut self`, so borrow checker will prevent use of buffer after seek.
+            Some((self.key_impl(), self.value_impl()))
+        } else {
+            None
+        }
+    }
+
+    /// Returns a slice of the current key; assumes the iterator is valid.
+    fn key_impl(&self) -> &[u8] {
+        // Safety Note: This is safe as all methods that may invalidate the buffer returned
+        // take `&mut self`, so borrow checker will prevent use of buffer after seek.
+        unsafe {
+            let mut key_len: size_t = 0;
+            let key_len_ptr: *mut size_t = &mut key_len;
+            let key_ptr = ffi::rocksdb_iter_key(self.inner, key_len_ptr) as *const c_uchar;
+            slice::from_raw_parts(key_ptr, key_len as usize)
+        }
+    }
+
+    /// Returns a slice of the current value; assumes the iterator is valid.
+    fn value_impl(&self) -> &[u8] {
+        // Safety Note: This is safe as all methods that may invalidate the buffer returned
+        // take `&mut self`, so borrow checker will prevent use of buffer after seek.
+        unsafe {
+            let mut val_len: size_t = 0;
+            let val_len_ptr: *mut size_t = &mut val_len;
+            let val_ptr = ffi::rocksdb_iter_value(self.inner, val_len_ptr) as *const c_uchar;
+            slice::from_raw_parts(val_ptr, val_len as usize)
         }
     }
 }
@@ -470,12 +493,8 @@ impl<'a, D: DBAccess> Iterator for DBIteratorWithThreadMode<'a, D> {
             }
         }
 
-        if self.raw.valid() {
-            // .key() and .value() only ever return None if valid == false, which we've just checked
-            Some((
-                Box::from(self.raw.key().unwrap()),
-                Box::from(self.raw.value().unwrap()),
-            ))
+        if let Some((key, value)) = self.raw.item() {
+            Some((Box::from(key), Box::from(value)))
         } else {
             None
         }

--- a/tests/test_raw_iterator.rs
+++ b/tests/test_raw_iterator.rs
@@ -16,8 +16,26 @@ mod util;
 
 use pretty_assertions::assert_eq;
 
-use rocksdb::DB;
+use rocksdb::{DBAccess, DBRawIteratorWithThreadMode, DB};
 use util::DBPath;
+
+fn assert_item<'a, D: DBAccess>(
+    iter: &DBRawIteratorWithThreadMode<'a, D>,
+    key: &[u8],
+    value: &[u8],
+) {
+    assert!(iter.valid());
+    assert_eq!(iter.key(), Some(key));
+    assert_eq!(iter.value(), Some(value));
+    assert_eq!(iter.item(), Some((key, value)));
+}
+
+fn assert_no_item<'a, D: DBAccess>(iter: &DBRawIteratorWithThreadMode<'a, D>) {
+    assert!(!iter.valid());
+    assert_eq!(iter.key(), None);
+    assert_eq!(iter.value(), None);
+    assert_eq!(iter.item(), None);
+}
 
 #[test]
 pub fn test_forwards_iteration() {
@@ -31,24 +49,16 @@ pub fn test_forwards_iteration() {
 
         let mut iter = db.raw_iterator();
         iter.seek_to_first();
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k1".as_ref()));
-        assert_eq!(iter.value(), Some(b"v1".as_ref()));
+        assert_item(&iter, b"k1", b"v1");
 
         iter.next();
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k2".as_ref()));
-        assert_eq!(iter.value(), Some(b"v2".as_ref()));
+        assert_item(&iter, b"k2", b"v2");
 
         iter.next(); // k3
         iter.next(); // k4
-        iter.next(); // invalid!
 
-        assert!(!iter.valid());
-        assert_eq!(iter.key(), None);
-        assert_eq!(iter.value(), None);
+        iter.next(); // invalid!
+        assert_no_item(&iter);
     }
 }
 
@@ -64,24 +74,16 @@ pub fn test_seek_last() {
 
         let mut iter = db.raw_iterator();
         iter.seek_to_last();
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k4".as_ref()));
-        assert_eq!(iter.value(), Some(b"v4".as_ref()));
+        assert_item(&iter, b"k4", b"v4");
 
         iter.prev();
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k3".as_ref()));
-        assert_eq!(iter.value(), Some(b"v3".as_ref()));
+        assert_item(&iter, b"k3", b"v3");
 
         iter.prev(); // k2
         iter.prev(); // k1
-        iter.prev(); // invalid!
 
-        assert!(!iter.valid());
-        assert_eq!(iter.key(), None);
-        assert_eq!(iter.value(), None);
+        iter.prev(); // invalid!
+        assert_no_item(&iter);
     }
 }
 
@@ -97,16 +99,11 @@ pub fn test_seek() {
         let mut iter = db.raw_iterator();
         iter.seek(b"k2");
 
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k2".as_ref()));
-        assert_eq!(iter.value(), Some(b"v2".as_ref()));
+        assert_item(&iter, b"k2", b"v2");
 
         // Check it gets the next key when the key doesn't exist
         iter.seek(b"k3");
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k4".as_ref()));
-        assert_eq!(iter.value(), Some(b"v4".as_ref()));
+        assert_item(&iter, b"k4", b"v4");
     }
 }
 
@@ -121,10 +118,7 @@ pub fn test_seek_to_nonexistant() {
 
         let mut iter = db.raw_iterator();
         iter.seek(b"k2");
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k3".as_ref()));
-        assert_eq!(iter.value(), Some(b"v3".as_ref()));
+        assert_item(&iter, b"k3", b"v3");
     }
 }
 
@@ -139,16 +133,10 @@ pub fn test_seek_for_prev() {
 
         let mut iter = db.raw_iterator();
         iter.seek(b"k2");
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k2".as_ref()));
-        assert_eq!(iter.value(), Some(b"v2".as_ref()));
+        assert_item(&iter, b"k2", b"v2");
 
         // Check it gets the previous key when the key doesn't exist
         iter.seek_for_prev(b"k3");
-
-        assert!(iter.valid());
-        assert_eq!(iter.key(), Some(b"k2".as_ref()));
-        assert_eq!(iter.value(), Some(b"v2".as_ref()));
+        assert_item(&iter, b"k2", b"v2");
     }
 }


### PR DESCRIPTION
The method is morally equivalent to calling `key` and `value` methods
separately however it reduces number of times validity of the iterator
needs to be checked.  Since that check goes through ffi layer and
calls a virtual method it doesn’t optimise well.  Therefore, reducing
number of times the `valid` method is called optimises the code a wee
bit.