### PR TITLE
Avoid pulling in dependencies via static feature flag

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -14,7 +14,7 @@ links = "rocksdb"
 [features]
 default = [ "static" ]
 jemalloc = ["tikv-jemalloc-sys"]
-static = ["libz-sys/static", "bzip2-sys/static"]
+static = ["libz-sys?/static", "bzip2-sys?/static"]
 snappy = []
 lz4 = []
 zstd = ["zstd-sys"]


### PR DESCRIPTION
The `static` feature flag needs to set feature flags in dependencies. Unfortunately this unconditionally pulls in the dependency, even if it would not otherwise be enabled/needed.

Rust 1.60 [introduces weak dependency features](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features) for this exact use case.

Do we have a policy about the minimum supported Rust version?