### PR TITLE
Update `zstd-sys` from `1.6` to `2.0`

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -25,7 +25,7 @@ rtti = []
 [dependencies]
 libc = "0.2"
 tikv-jemalloc-sys = { version = "0.4", features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
-zstd-sys = { version = "1.6", default-features = false, optional = true }
+zstd-sys = { version = "2.0", features = ["zdict_builder"], optional = true }
 libz-sys = { version = "1.1", default-features = false, optional = true }
 bzip2-sys = { version = "0.1", default-features = false, optional = true }
 


### PR DESCRIPTION
### Issue

When using `rocksdb`, it is not possible to use another rust crate that depends on a more recent version of `zstd-sys`, because of a major version conflict[^1].

### Fix

```diff
-zstd-sys = { version = "1.6", default-features = false, optional = true }
+zstd-sys = { version = "2.0", features = ["zdict_builder"], optional = true }
```

Updates `zstd-sys` from `1.6` to `2.0` in `librocksdb-sys`. We additionally add the `zdict_builder` feature flag. Reading through the `zstd-rs` [commit log](https://github.com/gyscos/zstd-rs/commits/master/zstd-safe/zstd-sys), the reason for the breaking change is as follows:

```
commit 3a6c7fa76b49928bd4afc6a68ae82fce842df8dd (tag: v0.11.0)
Author: Alexandre Bury <alexandre.bury@gmail.com>
Date:   Wed Mar 9 15:48:49 2022 -0500

    Bump version to 0.11.0

    zstd-sys 2.0.0
    zstd-safe 5.0.0

    Breaking changes:
    - Dictionary-training operations have been moved behind a zdict_builder feature.
```

Adding the `zdict_builder` feature flag ensures that no regressions are introduced: all `rocksdb` tests pass locally running `cargo test`; additionally, running this patch against another codebase that depends on `rocksdb` does not appear to introduce any regressions.

### Motivation

We are currently using a [fork](https://github.com/rust-rocksdb/rust-rocksdb/compare/master...zed-industries:rust-rocksdb:master) of this codebase due to this issue, and would appreciate it if this minimal fix could be upstreamed. Thank you!

[^1]: This is because "Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary." See https://doc.rust-lang.org/cargo/reference/resolver.html?highlight=links#links for more info.