### PR TITLE
Don’t hold onto ReadOptions.inner when iterating

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -336,8 +336,8 @@ pub struct BlockBasedOptions {
 
 pub struct ReadOptions {
     pub(crate) inner: *mut ffi::rocksdb_readoptions_t,
-    iterate_upper_bound: Option<Vec<u8>>,
-    iterate_lower_bound: Option<Vec<u8>>,
+    pub(crate) iterate_upper_bound: Option<Vec<u8>>,
+    pub(crate) iterate_lower_bound: Option<Vec<u8>>,
 }
 
 /// Configuration of cuckoo-based storage.


### PR DESCRIPTION
Once iterator is created, ReadOptions.inner is no longer accessed by
the C code (the C iterator copies the options).  Only the lower and
upper bounds need to be kept around since the inner iterator holds
only pointers to them (i.e. borrows them).  It’s thus enough to keep
the bounds around; the inner objects can be safely dropped.

Change DBRawIteratorWithThreadMode to store just the bounds which
saves one pointer worth of space from the struct and allows inner
read options object to be freed as soon as iterator is created.
