### PR TITLE
Revert "Don’t hold onto ReadOptions.inner when iterating"

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -336,8 +336,8 @@ pub struct BlockBasedOptions {
 
 pub struct ReadOptions {
     pub(crate) inner: *mut ffi::rocksdb_readoptions_t,
-    pub(crate) iterate_upper_bound: Option<Vec<u8>>,
-    pub(crate) iterate_lower_bound: Option<Vec<u8>>,
+    iterate_upper_bound: Option<Vec<u8>>,
+    iterate_lower_bound: Option<Vec<u8>>,
 }
 
 /// Configuration of cuckoo-based storage.


### PR DESCRIPTION
Turns out there’s a two-step reference chain for lower and upper bound.
The C++ ReadOptions refer slices inside of the rocksdb_readoptions_t
C wrapper which refer to Rust vectors.   Holding onto the vectors is
insufficient for all the references to be valid.

This reverts commit 947e4b63034fff2151f52c399a5d85925ea80911.

Fixes: https://github.com/rust-rocksdb/rust-rocksdb/issues/660