### PR TITLE
Use lz4-sys crate (fixes #666, fixes #617, fixes #575)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "rocksdb_sys/rocksdb"]
 	path = librocksdb-sys/rocksdb
 	url = https://github.com/facebook/rocksdb.git
-[submodule "librocksdb-sys/lz4"]
-	path = librocksdb-sys/lz4
-	url = https://github.com/lz4/lz4.git

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -17,7 +17,7 @@ jemalloc = ["tikv-jemalloc-sys"]
 static = ["libz-sys?/static", "bzip2-sys?/static"]
 io-uring = ["pkg-config"]
 snappy = []
-lz4 = []
+lz4 = ["lz4-sys"]
 zstd = ["zstd-sys"]
 zlib = ["libz-sys"]
 bzip2 = ["bzip2-sys"]
@@ -26,6 +26,7 @@ rtti = []
 [dependencies]
 libc = "0.2"
 tikv-jemalloc-sys = { version = "0.5", features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
+lz4-sys = { version = "1.9", optional = true }
 zstd-sys = { version = "2.0", features = ["zdict_builder"], optional = true }
 libz-sys = { version = "1.1", default-features = false, optional = true }
 bzip2-sys = { version = "0.1", default-features = false, optional = true }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -63,7 +63,9 @@ fn build_rocksdb() {
 
     if cfg!(feature = "lz4") {
         config.define("LZ4", Some("1"));
-        config.include("lz4/lib/");
+        if let Some(path) = env::var_os("DEP_LZ4_INCLUDE") {
+            config.include(path);
+        }
     }
 
     if cfg!(feature = "zstd") {
@@ -285,26 +287,6 @@ fn build_snappy() {
     config.compile("libsnappy.a");
 }
 
-fn build_lz4() {
-    let mut compiler = cc::Build::new();
-
-    compiler
-        .file("lz4/lib/lz4.c")
-        .file("lz4/lib/lz4frame.c")
-        .file("lz4/lib/lz4hc.c")
-        .file("lz4/lib/xxhash.c");
-
-    compiler.opt_level(3);
-
-    let target = env::var("TARGET").unwrap();
-
-    if &target == "i686-pc-windows-gnu" {
-        compiler.flag("-fno-tree-vectorize");
-    }
-
-    compiler.compile("liblz4.a");
-}
-
 fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     if let Ok(v) = env::var(&format!("{}_COMPILE", lib_name)) {
         if v.to_lowercase() == "true" || v == "1" {
@@ -377,11 +359,6 @@ fn main() {
         println!("cargo:rerun-if-changed=snappy/");
         fail_on_empty_directory("snappy");
         build_snappy();
-    }
-    if cfg!(feature = "lz4") && !try_to_find_and_link_lib("LZ4") {
-        println!("cargo:rerun-if-changed=lz4/");
-        fail_on_empty_directory("lz4");
-        build_lz4();
     }
 
     // Allow dependent crates to locate the sources and output directory of

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -22,6 +22,8 @@
 extern crate bzip2_sys;
 #[cfg(feature = "zlib")]
 extern crate libz_sys;
+#[cfg(feature = "lz4")]
+extern crate lz4_sys;
 #[cfg(feature = "zstd")]
 extern crate zstd_sys;
 


### PR DESCRIPTION
Thanks to https://github.com/10XGenomics/lz4-rs/pull/27 it is now
possible to use the lz4-sys crate instead of a submodule.

This allows other crates to also link lz4.

Additionally, the latest version fixes CVE-2021-3520. I don't think it
was possible to exploit this in RocksDB, because RocksDB will only
decompress payloads it has previously compressed itself.