### PR TITLE
Fix clippy warnings

### DIFF
--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -221,48 +221,9 @@ unsafe extern "C" fn CmpName(arg: *mut c_void) -> *const c_char {
     cstrp!("foo")
 }
 
-// Custom filter policy
+// Custom compaction filter
 
 static mut fake_filter_result: c_uchar = 1;
-
-unsafe extern "C" fn FilterDestroy(arg: *mut c_void) {}
-
-unsafe extern "C" fn FilterName(arg: *mut c_void) -> *const c_char {
-    cstrp!("TestFilter")
-}
-
-unsafe extern "C" fn FilterCreate(
-    arg: *mut c_void,
-    key_array: *const *const c_char,
-    key_length_array: *const size_t,
-    num_keys: c_int,
-    filter_length: *mut size_t,
-) -> *mut c_char {
-    *filter_length = 4;
-    let result = malloc(4);
-    memcpy(result, cstrp!("fake") as *const c_void, 4);
-    result as *mut c_char
-}
-
-unsafe extern "C" fn FilterKeyMatch(
-    arg: *mut c_void,
-    key: *const c_char,
-    length: size_t,
-    filter: *const c_char,
-    filter_length: size_t,
-) -> c_uchar {
-    CheckCondition!(filter_length == 4);
-    CheckCondition!(
-        memcmp(
-            filter as *const c_void,
-            cstrp!("fake") as *const c_void,
-            filter_length
-        ) == 0
-    );
-    fake_filter_result
-}
-
-// Custom compaction filter
 
 unsafe extern "C" fn CFilterDestroy(arg: *mut c_void) {}
 

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -860,7 +860,7 @@ impl Default for CuckooTableOptions {
 }
 
 // Verbosity of the LOG.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum LogLevel {
     Debug = 0,
@@ -3271,7 +3271,7 @@ impl Default for WriteOptions {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 #[repr(i32)]
 pub enum ReadTier {
@@ -3644,7 +3644,7 @@ pub struct PlainTableFactoryOptions {
     pub index_sparseness: usize,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum DBCompressionType {
     None = ffi::rocksdb_no_compression as isize,
@@ -3656,7 +3656,7 @@ pub enum DBCompressionType {
     Zstd = ffi::rocksdb_zstd_compression as isize,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum DBCompactionStyle {
     Level = ffi::rocksdb_level_compaction as isize,
@@ -3664,7 +3664,7 @@ pub enum DBCompactionStyle {
     Fifo = ffi::rocksdb_fifo_compaction as isize,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum DBRecoveryMode {
     TolerateCorruptedTailRecords = ffi::rocksdb_tolerate_corrupted_tail_records_recovery as isize,
@@ -3674,7 +3674,7 @@ pub enum DBRecoveryMode {
 }
 
 /// File access pattern once a compaction has started
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 #[repr(i32)]
 pub enum AccessHint {
@@ -3722,7 +3722,7 @@ impl FifoCompactOptions {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum UniversalCompactionStopStyle {
     Similar = ffi::rocksdb_similar_size_compaction_stop_style as isize,
@@ -3838,7 +3838,7 @@ impl UniversalCompactOptions {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 pub enum BottommostLevelCompaction {

--- a/src/db_pinnable_slice.rs
+++ b/src/db_pinnable_slice.rs
@@ -34,7 +34,7 @@ unsafe impl<'a> Sync for DBPinnableSlice<'a> {}
 impl<'a> AsRef<[u8]> for DBPinnableSlice<'a> {
     fn as_ref(&self) -> &[u8] {
         // Implement this via Deref so as not to repeat ourselves
-        &*self
+        &**self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub enum ErrorKind {
 
 /// A simple wrapper round a string, used for errors reported from
 /// ffi calls.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Error {
     message: String,
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -16,7 +16,7 @@ use libc::{c_int, c_uchar, c_void};
 
 use crate::{db::DBInner, ffi, ffi_util::from_cstr, Cache, Error, DB};
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(i32)]
 pub enum PerfStatsLevel {
     /// Unknown settings
@@ -36,7 +36,7 @@ pub enum PerfStatsLevel {
     OutOfBound,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 #[repr(i32)]
 pub enum PerfMetric {


### PR DESCRIPTION
* Eagerly derive common traits
* Clarify deref
* Remove unused functions from FFI test