### PR TITLE
Fix int128 compatibility check(Issue #681)

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -233,7 +233,6 @@ fn build_rocksdb() {
     } else {
         config.flag(&cxx_standard());
         // matches the flags in CMakeLists.txt from rocksdb
-        config.define("HAVE_UINT128_EXTENSION", Some("1"));
         config.flag("-Wsign-compare");
         config.flag("-Wshadow");
         config.flag("-Wno-unused-parameter");


### PR DESCRIPTION
Fix #681 

delete 'config.define("HAVE_UINT128_EXTENSION", Some("1"));' in [build.rs](https://github.com/rust-rocksdb/rust-rocksdb/blob/master/librocksdb-sys/build.rs#L236), which can cause Issue #681 

Not all compilers support the type of int128, so the https://github.com/facebook/rocksdb/pull/7338 uses makefile to check int128 compatibility. The type of int128 is not related to target, but related to compiler。