### PR TITLE
make sure build.rs is re-run, when env vars change

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -300,11 +300,9 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 
     if let Ok(lib_dir) = env::var(&format!("{}_LIB_DIR", lib_name)) {
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        let mode = match env::var_os(&format!("{}_STATIC", lib_name))
-            .as_ref()
-        {
+        let mode = match env::var_os(&format!("{}_STATIC", lib_name)) {
             Some(_) => "static",
-            _ => "dylib",
+            None => "dylib",
         };
         println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());
         return true;

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -299,7 +299,10 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     println!("cargo:rerun-if-env-changed={}_STATIC", lib_name);
     if let Ok(lib_dir) = env::var(&format!("{}_LIB_DIR", lib_name)) {
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        let mode = match env::var(&format!("{}_STATIC", lib_name)).as_ref().ok().map(|s| s.as_str()) {
+        let mode = match env::var_os(&format!("{}_STATIC", lib_name))
+            .as_ref()
+            .and_then(|s| s.to_str())
+        {
             Some("") | Some("true") | Some("1") | Some("static") => "static",
             _ => "dylib",
         };

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -297,13 +297,13 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
 
     println!("cargo:rerun-if-env-changed={}_LIB_DIR", lib_name);
     println!("cargo:rerun-if-env-changed={}_STATIC", lib_name);
+
     if let Ok(lib_dir) = env::var(&format!("{}_LIB_DIR", lib_name)) {
         println!("cargo:rustc-link-search=native={}", lib_dir);
         let mode = match env::var_os(&format!("{}_STATIC", lib_name))
             .as_ref()
-            .and_then(|s| s.to_str())
         {
-            Some("") | Some("true") | Some("1") | Some("yes") | Some("static") => "static",
+            Some(_) => "static",
             _ => "dylib",
         };
         println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -303,7 +303,7 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
             .as_ref()
             .and_then(|s| s.to_str())
         {
-            Some("") | Some("true") | Some("1") | Some("static") => "static",
+            Some("") | Some("true") | Some("1") | Some("yes") | Some("static") => "static",
             _ => "dylib",
         };
         println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -288,16 +288,19 @@ fn build_snappy() {
 }
 
 fn try_to_find_and_link_lib(lib_name: &str) -> bool {
+    println!("cargo:rerun-if-env-changed={}_COMPILE", lib_name);
     if let Ok(v) = env::var(&format!("{}_COMPILE", lib_name)) {
         if v.to_lowercase() == "true" || v == "1" {
             return false;
         }
     }
 
+    println!("cargo:rerun-if-env-changed={}_LIB_DIR", lib_name);
+    println!("cargo:rerun-if-env-changed={}_STATIC", lib_name);
     if let Ok(lib_dir) = env::var(&format!("{}_LIB_DIR", lib_name)) {
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        let mode = match env::var_os(&format!("{}_STATIC", lib_name)) {
-            Some(_) => "static",
+        let mode = match env::var(&format!("{}_STATIC", lib_name)) {
+            Some("") | Some("true") | Some("1") | Some("static") => "static",
             None => "dylib",
         };
         println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -299,9 +299,9 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     println!("cargo:rerun-if-env-changed={}_STATIC", lib_name);
     if let Ok(lib_dir) = env::var(&format!("{}_LIB_DIR", lib_name)) {
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        let mode = match env::var(&format!("{}_STATIC", lib_name)) {
+        let mode = match env::var(&format!("{}_STATIC", lib_name)).as_ref().ok().map(|s| s.as_str()) {
             Some("") | Some("true") | Some("1") | Some("static") => "static",
-            None => "dylib",
+            _ => "dylib",
         };
         println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());
         return true;


### PR DESCRIPTION
Currently a change in linkage mode env vars will not trigger a re-run of the `build.rs`-binary, and hence compilations fail until the that binary is deleted or other triggers are manually triggered.

To my understanding, it's a mere lag of 3 lines telling cargo to re-run the build script on env var change.

Also adds the option to _NOT_ link statically if i.e. `ROCKSDB_STATIC=false` is provided