### PR TITLE
Make set_snapshot public (simple pull request)

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3303,7 +3303,7 @@ impl ReadOptions {
     /// Sets the snapshot which should be used for the read.
     /// The snapshot must belong to the DB that is being read and must
     /// not have been released.
-    pub(crate) fn set_snapshot<D: DBAccess>(&mut self, snapshot: &SnapshotWithThreadMode<D>) {
+    pub fn set_snapshot<D: DBAccess>(&mut self, snapshot: &SnapshotWithThreadMode<D>) {
         unsafe {
             ffi::rocksdb_readoptions_set_snapshot(self.inner, snapshot.inner);
         }


### PR DESCRIPTION
Good day!
I'm writing my database on top of rocks db. And I have a problem:
I want to cache snapshot (for consistency) iterator between different batch requests for stream processing, but current implementation requires lifetime and lifetime is incompatible with caching.
I'd like to do simple workaround via ReadOptions, but method set_snapshot is private. So I want to make it public =)

my current solution is:
```rust
let db: &'static DB = todo!();
let  column_family: &'static ColumnFamily = todo!();
let snapshot = db.snapshot();
let mut options = rocksdb::ReadOptions::default();
options.set_snapshot(&snapshot);
let iter = db.raw_iterator_cf_opt(column_family, options);
```