### PR TITLE
Add drop_cf function to TransactionDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 path
 .DS_Store
 .idea
+.vscode

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -935,7 +935,7 @@ impl<T: ThreadMode> TransactionDB<T> {
     fn drop_column_family<C>(
         &self,
         cf_inner: *mut ffi::rocksdb_column_family_handle_t,
-        cf: C,
+        _cf: C,
     ) -> Result<(), Error> {
         unsafe {
             // first mark the column family as dropped
@@ -944,9 +944,8 @@ impl<T: ThreadMode> TransactionDB<T> {
                 cf_inner
             ));
         }
-        // then finally reclaim any resources (mem, files) by destroying the only single column
-        // family handle by drop()-ing it
-        drop(cf);
+        // Since `_cf` is dropped here, the column family handle is destroyed
+        // and any resources (mem, files) are reclaimed.
         Ok(())
     }
 }
@@ -971,7 +970,7 @@ impl TransactionDB<SingleThreaded> {
         if let Some(cf) = self.cfs.cfs.remove(name) {
             self.drop_column_family(cf.inner, cf)
         } else {
-            Err(Error::new(format!("Invalid column family: {}", name)))
+            Err(Error::new(format!("Invalid column family: {name}")))
         }
     }
 }
@@ -1004,7 +1003,7 @@ impl TransactionDB<MultiThreaded> {
         if let Some(cf) = self.cfs.cfs.write().unwrap().remove(name) {
             self.drop_column_family(cf.inner, cf)
         } else {
-            Err(Error::new(format!("Invalid column family: {}", name)))
+            Err(Error::new(format!("Invalid column family: {name}")))
         }
     }
 }

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -16,16 +16,18 @@ mod util;
 
 use pretty_assertions::assert_eq;
 
-use rocksdb::{
-    ColumnFamilyDescriptor, MergeOperands, MultiThreaded, Options, SingleThreaded, DB,
-    DEFAULT_COLUMN_FAMILY_NAME,
-};
+use rocksdb::{ColumnFamilyDescriptor, MergeOperands, Options, DB, DEFAULT_COLUMN_FAMILY_NAME};
 use rocksdb::{TransactionDB, TransactionDBOptions};
 use util::DBPath;
 
 use std::fs;
 use std::io;
 use std::path::Path;
+
+#[cfg(feature = "multi-threaded-cf")]
+use rocksdb::MultiThreaded;
+#[cfg(not(feature = "multi-threaded-cf"))]
+use rocksdb::SingleThreaded;
 
 fn dir_size(path: impl AsRef<Path>) -> io::Result<u64> {
     fn dir_size(mut dir: fs::ReadDir) -> io::Result<u64> {

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -191,10 +191,6 @@ fn test_column_family_with_transactiondb() {
         }
     }
 
-    // TODO should be able to use writebatch ops with a cf
-    {}
-    // TODO should be able to iterate over a cf
-    {}
     // should b able to drop a cf
     {
         let opts = Options::default();

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -16,7 +16,11 @@ mod util;
 
 use pretty_assertions::assert_eq;
 
-use rocksdb::{ColumnFamilyDescriptor, MergeOperands, Options, DB, DEFAULT_COLUMN_FAMILY_NAME};
+use rocksdb::{
+    ColumnFamilyDescriptor, MergeOperands, MultiThreaded, Options, SingleThreaded, DB,
+    DEFAULT_COLUMN_FAMILY_NAME,
+};
+use rocksdb::{TransactionDB, TransactionDBOptions};
 use util::DBPath;
 
 use std::fs;
@@ -109,6 +113,132 @@ fn test_column_family() {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),
         }
+    }
+}
+
+#[test]
+fn test_column_family_with_transactiondb() {
+    let n = DBPath::new("_rust_rocksdb_cftest");
+
+    // should be able to create column families
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.set_merge_operator_associative("test operator", test_provided_merge);
+        #[cfg(feature = "multi-threaded-cf")]
+        let db = TransactionDB::open(&opts, &TransactionDBOptions::default(), &n).unwrap();
+        #[cfg(not(feature = "multi-threaded-cf"))]
+        let db = TransactionDB::open(&opts, &TransactionDBOptions::default(), &n).unwrap();
+        let opts = Options::default();
+        match db.create_cf("cf1", &opts) {
+            Ok(()) => println!("cf1 created successfully"),
+            Err(e) => {
+                panic!("could not create column family: {}", e);
+            }
+        }
+    }
+
+    // should fail to open db without specifying same column families
+    {
+        let mut opts = Options::default();
+        opts.set_merge_operator_associative("test operator", test_provided_merge);
+        #[cfg(feature = "multi-threaded-cf")]
+        let db = TransactionDB::<MultiThreaded>::open(&opts, &TransactionDBOptions::default(), &n);
+        #[cfg(not(feature = "multi-threaded-cf"))]
+        let db = TransactionDB::<SingleThreaded>::open(&opts, &TransactionDBOptions::default(), &n);
+        match db {
+            Ok(_db) => panic!(
+                "should not have opened TransactionDB successfully without \
+                        specifying column
+            families"
+            ),
+            Err(e) => assert!(e.to_string().starts_with("Invalid argument")),
+        }
+    }
+
+    // should properly open db when specyfing all column families
+    {
+        let mut opts = Options::default();
+        opts.set_merge_operator_associative("test operator", test_provided_merge);
+        let cfs = &["cf1"];
+        #[cfg(feature = "multi-threaded-cf")]
+        let db = TransactionDB::<MultiThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        );
+        #[cfg(not(feature = "multi-threaded-cf"))]
+        let db = TransactionDB::<SingleThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        );
+        match db {
+            Ok(_db) => println!("successfully opened db with column family"),
+            Err(e) => panic!("failed to open db with column family: {}", e),
+        }
+    }
+
+    // should be able to list a cf
+    {
+        let opts = Options::default();
+        let vec = DB::list_cf(&opts, &n);
+        match vec {
+            Ok(vec) => assert_eq!(vec, vec![DEFAULT_COLUMN_FAMILY_NAME, "cf1"]),
+            Err(e) => panic!("failed to drop column family: {}", e),
+        }
+    }
+
+    // TODO should be able to use writebatch ops with a cf
+    {}
+    // TODO should be able to iterate over a cf
+    {}
+    // should b able to drop a cf
+    {
+        let opts = Options::default();
+        let cfs = &["cf1"];
+        #[cfg(feature = "multi-threaded-cf")]
+        let mut db = TransactionDB::<MultiThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        )
+        .unwrap();
+        #[cfg(not(feature = "multi-threaded-cf"))]
+        let mut db = TransactionDB::<SingleThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        )
+        .unwrap();
+        match db.drop_cf("cf1") {
+            Ok(_) => println!("cf1 successfully dropped."),
+            Err(e) => panic!("failed to drop column family: {}", e),
+        }
+    }
+    // should not be able to open cf after dropping.
+    {
+        let opts = Options::default();
+        let cfs = &["cf1"];
+        #[cfg(feature = "multi-threaded-cf")]
+        let db = TransactionDB::<MultiThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        );
+        #[cfg(not(feature = "multi-threaded-cf"))]
+        let db = TransactionDB::<SingleThreaded>::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &n,
+            cfs,
+        );
+        assert!(db.is_err())
     }
 }
 


### PR DESCRIPTION
Since `TransactionDB` is a subclass of `StackableDB` which is subclass of `DB`, there's no reason for the `drop_cf` function should be callable directly from TransactionDB.

The core of this change is a cast in `transaction_db.rs`:
```rust
self.inner as *mut ffi::rocksdb_t,
```

The PR also includes a test, but that's mostly copy-pasted from a similar test on `DB`, with the addition of testing for error when opening a previously deleted column family to make sure that the drop was actually successful.