### PR TITLE
Actually enable io-uring

### DIFF
--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -23,6 +23,10 @@ static const std::string rocksdb_build_date = "rocksdb_build_date:2023-02-19 21:
 
 std::unordered_map<std::string, ROCKSDB_NAMESPACE::RegistrarFunc> ROCKSDB_NAMESPACE::ObjectRegistry::builtins_ = {};
 
+extern "C" bool RocksDbIOUringEnable() {
+  return true;
+}
+
 namespace ROCKSDB_NAMESPACE {
 static void AddProperty(std::unordered_map<std::string, std::string> *props, const std::string& name) {
   size_t colon = name.find(":");

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3441,6 +3441,11 @@ impl ReadOptions {
         }
     }
 
+    /// Asynchronously prefetch some data.
+    ///
+    /// Used for sequential reads and internal automatic prefetching.
+    ///
+    /// Default: `false`
     pub fn set_async_io(&mut self, v: bool) {
         unsafe {
             ffi::rocksdb_readoptions_set_async_io(self.inner, c_uchar::from(v));

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3440,6 +3440,12 @@ impl ReadOptions {
             ffi::rocksdb_readoptions_set_pin_data(self.inner, c_uchar::from(v));
         }
     }
+
+    pub fn set_async_io(&mut self, v: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_async_io(self.inner, c_uchar::from(v));
+        }
+    }
 }
 
 impl Default for ReadOptions {


### PR DESCRIPTION
I just tried and failed to actually use io-uring with RocksDB. Turns out, in addition to the compiler flag, users also have to define the `RocksDbIOUringEnable` symbol.

Does nothing if `ROCKSDB_IOURING_PRESENT` is not defined (when the `io-uring` feature flag is off).

https://github.com/facebook/rocksdb/blob/3c9eed688ec912e0c5526a6c1ef23948b50c59b3/env/fs_posix.cc#L76