### PR TITLE
Fix 32-bit ARM build

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -226,6 +226,11 @@ fn build_rocksdb() {
         config.define("ROCKSDB_IOURING_PRESENT", Some("1"));
     }
 
+    if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() != "64" {
+        config.define("_FILE_OFFSET_BITS", Some("64"));
+        config.define("_LARGEFILE64_SOURCE", Some("1"));
+    }
+
     if target.contains("msvc") {
         config.flag("-EHsc");
         config.flag("-std:c++17");


### PR DESCRIPTION
Building this crate on `arm-linux-gnueabihf` is fine, HOWEVER, opening a rocksdb database using the built code fails:

On our CI, we get a "Value too large for defined data type" in our functional tests, see [build output](https://build.bitcoinabc.org/repository/download/BitcoinABC_BitcoinAbcStaging/515561:id/artifacts.tar.gz!/functional/test_runner_%E2%82%BF%E2%82%B5_%F0%9F%8F%83_20230302_193244/chronik_block_214/node0/regtest/debug.log) (you can login as guest if necessary).

After a bit of digging, it turns out this refers to a [missing environment variable specifically for 32-bit systems that want to open files using 64-bit offsets](https://stackoverflow.com/a/23372153).

Therefore, this PR [fixes our build](https://build.bitcoinabc.org/viewLog.html?buildId=515991&buildTypeId=BitcoinABC_BitcoinAbcStaging&tab=buildResultsDiv&branch_BitcoinAbcDiffs=refs%2Ftags%2Fphabricator%2Fdiff%2F38261) by adding those two env variables when CARGO_CFG_TARGET_POINTER_WIDTH is not 64.