### PR TITLE
support for comparators as closures

### DIFF
--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -18,11 +18,11 @@ use std::cmp::Ordering;
 use std::ffi::CString;
 use std::slice;
 
-pub type CompareFn = fn(&[u8], &[u8]) -> Ordering;
+pub type CompareFn = dyn Fn(&[u8], &[u8]) -> Ordering;
 
 pub struct ComparatorCallback {
     pub name: CString,
-    pub f: CompareFn,
+    pub f: Box<CompareFn>,
 }
 
 pub unsafe extern "C" fn destructor_callback(raw_cb: *mut c_void) {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1300,7 +1300,7 @@ impl Options {
     /// The client must ensure that the comparator supplied here has the same
     /// name and orders keys *exactly* the same as the comparator provided to
     /// previous open calls on the same DB.
-    pub fn set_comparator(&mut self, name: impl CStrLike, compare_fn: CompareFn) {
+    pub fn set_comparator(&mut self, name: impl CStrLike, compare_fn: Box<CompareFn>) {
         let cb = Box::new(ComparatorCallback {
             name: name.into_c_string().unwrap(),
             f: compare_fn,
@@ -1323,13 +1323,6 @@ impl Options {
         }
     }
 
-    #[deprecated(
-        since = "0.5.0",
-        note = "add_comparator has been renamed to set_comparator"
-    )]
-    pub fn add_comparator(&mut self, name: &str, compare_fn: CompareFn) {
-        self.set_comparator(name, compare_fn);
-    }
 
     pub fn optimize_for_point_lookup(&mut self, cache_size: u64) {
         unsafe {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1323,7 +1323,6 @@ impl Options {
         }
     }
 
-
     pub fn optimize_for_point_lookup(&mut self, cache_size: u64) {
         unsafe {
             ffi::rocksdb_options_optimize_for_point_lookup(self.inner, cache_size);

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -44,9 +44,7 @@ pub fn write_to_db_with_comparator(
 /// Keep in mind that this variable must be moved to the clojure
 /// Then run a test with a reverse sorting clojure and make sure the order is reverted
 fn test_comparator() {
-    let local_compare = move |one: &[u8], two: &[u8]| {
-        one.cmp(two)
-    };
+    let local_compare = move |one: &[u8], two: &[u8]| one.cmp(two);
 
     let x = 0;
     let local_compare_reverse = move |one: &[u8], two: &[u8]| {

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -4,7 +4,7 @@ use std::iter::FromIterator;
 
 /// This function is for ensuring test of backwards compatibility
 pub fn rocks_old_compare(one: &[u8], two: &[u8]) -> Ordering {
-    return one.cmp(two);
+    one.cmp(two)
 }
 
 /// create database add some values, and iterate over these
@@ -34,7 +34,7 @@ pub fn write_to_db_with_comparator(
         }
     }
     let _ = DB::destroy(&Options::default(), path);
-    return result_vec;
+    result_vec
 }
 
 #[test]
@@ -45,7 +45,7 @@ pub fn write_to_db_with_comparator(
 /// Then run a test with a reverse sorting clojure and make sure the order is reverted
 fn test_comparator() {
     let local_compare = move |one: &[u8], two: &[u8]| {
-        return one.cmp(two);
+        one.cmp(two)
     };
 
     let x = 0;
@@ -54,11 +54,11 @@ fn test_comparator() {
             "Use the x value from the closure scope to do something smart: {:?}",
             x
         );
-        return match one.cmp(two) {
+        match one.cmp(two) {
             Ordering::Less => Ordering::Greater,
             Ordering::Equal => Ordering::Equal,
             Ordering::Greater => Ordering::Less,
-        };
+        }
     };
 
     let old_res = write_to_db_with_comparator(Box::new(rocks_old_compare));

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -1,0 +1,69 @@
+use rocksdb::{Options, DB};
+use std::iter::FromIterator;
+use std::{cmp::Ordering};
+
+/// This function is for ensuring test of backwards compatibility
+pub fn rocks_old_compare(one: &[u8], two: &[u8]) -> Ordering {
+    return one.cmp(two);
+}
+
+/// create database add some values, and iterate over these
+pub fn write_to_db_with_comparator(compare_fn: Box<dyn Fn(&[u8], &[u8]) -> Ordering>) -> Vec<String> {
+    let mut result_vec = Vec::new();
+
+    let path = "_path_for_rocksdb_storage";
+    {
+        let mut db_opts = Options::default();
+
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        db_opts.set_comparator("cname", compare_fn);
+        let db = DB::open(&db_opts, path).unwrap();
+        db.put(b"a-key", b"a-value").unwrap();
+        db.put(b"b-key", b"b-value").unwrap();
+        let mut iter = db.raw_iterator();
+        iter.seek_to_first();
+        while iter.valid() {
+            let key = iter.key().unwrap();
+            // maybe not best way to copy?
+            let key_str = key.iter().map(|b| *b as char).collect::<Vec<_>>();
+            result_vec.push(String::from_iter(key_str));
+            iter.next();
+        }
+    }
+    let _ = DB::destroy(&Options::default(), path);
+    return result_vec;
+}
+
+#[test]
+    /// First verify that using a function as a comparator works as expected
+    /// This should verify backwards compatablity
+    /// Then run a test with a clojure where an x-variable is passed
+    /// Keep in mind that this variable must be moved to the clojure 
+    /// Then run a test with a reverse sorting clojure and make sure the order is reverted
+fn test_comparator() {
+
+    let local_compare = move |one: &[u8], two: &[u8]| {
+        return one.cmp(two);
+     };
+
+    let x = 0;
+    let local_compare_reverse = move |one: &[u8], two: &[u8]| {
+        println!("Use the x value from the closure scope to do something smart: {:?}", x);
+        return match one.cmp(two) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        };
+    };
+
+    let old_res = write_to_db_with_comparator(Box::new(rocks_old_compare));
+    println!("Keys in normal sort order, no closure: {:?}", old_res);
+    assert_eq!(vec!["a-key", "b-key"], old_res);
+    let res_closure = write_to_db_with_comparator(Box::new(local_compare));
+    println!("Keys in normal sort order, closure: {:?}", res_closure);
+    assert_eq!(res_closure, old_res);
+    let res_closure_reverse = write_to_db_with_comparator(Box::new(local_compare_reverse));
+    println!("Keys in reverse sort order, closure: {:?}", res_closure_reverse);
+    assert_eq!(vec!["b-key", "a-key"], res_closure_reverse);
+}

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -1,6 +1,6 @@
 use rocksdb::{Options, DB};
+use std::cmp::Ordering;
 use std::iter::FromIterator;
-use std::{cmp::Ordering};
 
 /// This function is for ensuring test of backwards compatibility
 pub fn rocks_old_compare(one: &[u8], two: &[u8]) -> Ordering {
@@ -8,7 +8,9 @@ pub fn rocks_old_compare(one: &[u8], two: &[u8]) -> Ordering {
 }
 
 /// create database add some values, and iterate over these
-pub fn write_to_db_with_comparator(compare_fn: Box<dyn Fn(&[u8], &[u8]) -> Ordering>) -> Vec<String> {
+pub fn write_to_db_with_comparator(
+    compare_fn: Box<dyn Fn(&[u8], &[u8]) -> Ordering>,
+) -> Vec<String> {
     let mut result_vec = Vec::new();
 
     let path = "_path_for_rocksdb_storage";
@@ -36,20 +38,22 @@ pub fn write_to_db_with_comparator(compare_fn: Box<dyn Fn(&[u8], &[u8]) -> Order
 }
 
 #[test]
-    /// First verify that using a function as a comparator works as expected
-    /// This should verify backwards compatablity
-    /// Then run a test with a clojure where an x-variable is passed
-    /// Keep in mind that this variable must be moved to the clojure 
-    /// Then run a test with a reverse sorting clojure and make sure the order is reverted
+/// First verify that using a function as a comparator works as expected
+/// This should verify backwards compatablity
+/// Then run a test with a clojure where an x-variable is passed
+/// Keep in mind that this variable must be moved to the clojure
+/// Then run a test with a reverse sorting clojure and make sure the order is reverted
 fn test_comparator() {
-
     let local_compare = move |one: &[u8], two: &[u8]| {
         return one.cmp(two);
-     };
+    };
 
     let x = 0;
     let local_compare_reverse = move |one: &[u8], two: &[u8]| {
-        println!("Use the x value from the closure scope to do something smart: {:?}", x);
+        println!(
+            "Use the x value from the closure scope to do something smart: {:?}",
+            x
+        );
         return match one.cmp(two) {
             Ordering::Less => Ordering::Greater,
             Ordering::Equal => Ordering::Equal,
@@ -64,6 +68,9 @@ fn test_comparator() {
     println!("Keys in normal sort order, closure: {:?}", res_closure);
     assert_eq!(res_closure, old_res);
     let res_closure_reverse = write_to_db_with_comparator(Box::new(local_compare_reverse));
-    println!("Keys in reverse sort order, closure: {:?}", res_closure_reverse);
+    println!(
+        "Keys in reverse sort order, closure: {:?}",
+        res_closure_reverse
+    );
     assert_eq!(vec!["b-key", "a-key"], res_closure_reverse);
 }


### PR DESCRIPTION
I have updated the code for supporting comparators as closures.

Reason for this is that moving from functions to closures makes it possible to add more information into the comparator function. Let us for example say one is creating a sql-base and then would like to add a compound index, based on the create index statement. The sort order in the comparator should then depend on the directions of the sorting fields, for example first sort on a float and then an int.

The old solution did not support a way to add meta-info like this into the compare function in a dynamical way and this is currently solved by allowing the comparator to be a closure. By using the move-functionality with closures we can add extra context to the compare function.

The solution is backwards compatible, as it still supports functions as these can be casted to closures in Rust.

I have also added a test-file for comparators where I test backwards compatiblity, and the new solution with support for closures.

Feel free to drop a line to me on petter.egesund@gmail.com if you would like to discuss.