### PR TITLE
Fix bug in `DBWALIterator` that would miss updates

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1845,7 +1845,10 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 seq_number,
                 opts
             ));
-            Ok(DBWALIterator { inner: iter })
+            Ok(DBWALIterator {
+                inner: iter,
+                start_seq_number: seq_number,
+            })
         }
     }
 


### PR DESCRIPTION
I found a bug in the `DBWALIterator` that would cause it to miss updates in certain scenarios.
One such scenario is calling `latest_sequence_number()` on a newly created DB which returns `0`, then writing a couple of things and calling `get_updates_since(0)`. This would cause the first batch returned by the iterator to be for sequence 2 and not 1 as expected.
The test case I added demonstrates this and fails without my fix.
I also suspect this would cause issues in scenarios where a given sequence number is in the past but no longer exists which causes RocksDB to return an iterator that starts after the sequence number based on the following documentation:
>Sets iter to an iterator that is positioned at a write-batch whose sequence number range [start_seq, end_seq] covers seq_number. If no such write-batch exists, then iter is positioned at the next write-batch whose start_seq > seq_number.

I'm not 100% sure if that scenario is possible but it's a bug nevertheless.

I've fixed the issue by checking if each returned batch's sequence number matches the one provided to `get_changes_since` and only if so, skip it. This should be safe as sequence numbers are monotonically increasing. 

I hope this can be merged and released ASAP as I need it for my project 😄 

Thank you.