### PR TITLE
Update to RocksDB 8.1.1

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librocksdb-sys"
-version = "0.11.0+8.0.0"
+version = "0.11.0+8.1.1"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]

--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -8,17 +8,17 @@
 
 // The build script may replace these values with real values based
 // on whether or not GIT is available and the platform settings
-static const std::string rocksdb_build_git_sha  = "fdf403f5918a2b4355cf75ebe5e21d0fc22db880";
-static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.0.0";
+static const std::string rocksdb_build_git_sha  = "6a436150417120a3f9732d65a2a5c2b8d19b60fc";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.1.1";
 #define HAS_GIT_CHANGES 0
 #if HAS_GIT_CHANGES == 0
 // If HAS_GIT_CHANGES is 0, the GIT date is used.
 // Use the time the branch/tag was last modified
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-02-19 21:44:55";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-04-06 16:38:52";
 #else
 // If HAS_GIT_CHANGES is > 0, the branch/tag has modifications.
 // Use the time the build was created.
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-02-19 21:44:55";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-04-06 16:38:52";
 #endif
 
 std::unordered_map<std::string, ROCKSDB_NAMESPACE::RegistrarFunc> ROCKSDB_NAMESPACE::ObjectRegistry::builtins_ = {};

--- a/librocksdb-sys/rocksdb_lib_sources.txt
+++ b/librocksdb-sys/rocksdb_lib_sources.txt
@@ -8,6 +8,7 @@ cache/clock_cache.cc
 cache/lru_cache.cc
 cache/compressed_secondary_cache.cc
 cache/secondary_cache.cc
+cache/secondary_cache_adapter.cc
 cache/sharded_cache.cc
 db/arena_wrapped_db_iter.cc
 db/blob/blob_contents.cc
@@ -94,6 +95,7 @@ db/wide/wide_columns.cc
 db/write_batch.cc
 db/write_batch_base.cc
 db/write_controller.cc
+db/write_stall_stats.cc
 db/write_thread.cc
 env/composite_env.cc
 env/env.cc
@@ -190,6 +192,7 @@ table/format.cc
 table/get_context.cc
 table/iterator.cc
 table/merging_iterator.cc
+table/compaction_merging_iterator.cc
 table/meta_blocks.cc
 table/persistent_cache_helper.cc
 table/plain/plain_table_bloom.cc


### PR DESCRIPTION
Brings C APIs that are a prerequisite to adding HyperClockCache support (and some minor bugfixes).

https://github.com/facebook/rocksdb/releases/tag/v8.1.1