### PR TITLE
Add Cache::new_hyper_clock_cache()

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -57,6 +57,35 @@ impl Cache {
         Cache(Arc::new(CacheWrapper { inner }))
     }
 
+    /// Creates a HyperClockCache with capacity in bytes.
+    ///
+    /// `estimated_entry_charge` is an important tuning parameter. The optimal
+    /// choice at any given time is
+    /// `(cache.get_usage() - 64 * cache.get_table_address_count()) /
+    /// cache.get_occupancy_count()`, or approximately `cache.get_usage() /
+    /// cache.get_occupancy_count()`.
+    ///
+    /// However, the value cannot be changed dynamically, so as the cache
+    /// composition changes at runtime, the following tradeoffs apply:
+    ///
+    /// * If the estimate is substantially too high (e.g., 25% higher),
+    ///   the cache may have to evict entries to prevent load factors that
+    ///   would dramatically affect lookup times.
+    /// * If the estimate is substantially too low (e.g., less than half),
+    ///   then meta data space overhead is substantially higher.
+    ///
+    /// The latter is generally peferable, and picking the larger of
+    /// block size and meta data block size is a reasonable choice that
+    /// errs towards this side.
+    pub fn new_hyper_clock_cache(capacity: size_t, estimated_entry_charge: size_t) -> Cache {
+        Cache(Arc::new(CacheWrapper {
+            inner: NonNull::new(unsafe {
+                ffi::rocksdb_cache_create_hyper_clock(capacity, estimated_entry_charge)
+            })
+            .unwrap(),
+        }))
+    }
+
     /// Returns the cache memory usage in bytes.
     pub fn get_usage(&self) -> usize {
         unsafe { ffi::rocksdb_cache_get_usage(self.0.inner.as_ptr()) }


### PR DESCRIPTION
We can now support HyperClockCache.

Corresponding C++ API: https://github.com/facebook/rocksdb/blob/a2c1f5735857f5a621982f316c57859f292969ea/include/rocksdb/cache.h#L288