### PR TITLE
db_options: Expose remaining PlainTableFactoryOptions

### DIFF
--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -1072,7 +1072,7 @@ fn ffi() {
                 rocksdb_slicetransform_create_fixed_prefix(3),
             );
             rocksdb_options_set_hash_skip_list_rep(options, 5000, 4, 4);
-            rocksdb_options_set_plain_table_factory(options, 4, 10, 0.75, 16);
+            rocksdb_options_set_plain_table_factory(options, 4, 10, 0.75, 16, 0, 0, 0, 0);
             rocksdb_options_set_allow_concurrent_memtable_write(options, 0);
 
             db = rocksdb_open(options, dbname, &mut err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub use crate::{
     db_options::{
         BlockBasedIndexType, BlockBasedOptions, BottommostLevelCompaction, Cache, ChecksumType,
         CompactOptions, CuckooTableOptions, DBCompactionStyle, DBCompressionType, DBPath,
-        DBRecoveryMode, DataBlockIndexType, FifoCompactOptions, FlushOptions,
+        DBRecoveryMode, DataBlockIndexType, EncodingType, FifoCompactOptions, FlushOptions,
         IngestExternalFileOptions, LogLevel, MemtableFactory, Options, PlainTableFactoryOptions,
         ReadOptions, UniversalCompactOptions, UniversalCompactionStopStyle, WriteOptions,
     },


### PR DESCRIPTION
This is intended to go along with
https://github.com/facebook/rocksdb/pull/11442.