### PR TITLE
Fix memory leak when calling get_writebatch and avoid unnecessary clones

### DIFF
--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -852,8 +852,8 @@ impl<'db, DB> Transaction<'db, DB> {
             let wi = ffi::rocksdb_transaction_get_writebatch_wi(self.inner);
             let mut len: usize = 0;
             let ptr = ffi::rocksdb_writebatch_wi_data(wi, &mut len as _);
-            let data = std::slice::from_raw_parts(ptr, len).to_owned();
-            let writebatch = ffi::rocksdb_writebatch_create_from(data.as_ptr(), data.len());
+            let writebatch = ffi::rocksdb_writebatch_create_from(ptr, len);
+            ffi::rocksdb_free(wi as *mut c_void);
             WriteBatchWithTransaction { inner: writebatch }
         }
     }


### PR DESCRIPTION
### Memory leak
It seems `wi` is not deallocated properly which causes a memory leak when calling `get_writebatch`.

[rocksdb_transaction_get_writebatch_wi](https://github.com/facebook/rocksdb/blob/main/db/c.cc#L5635) allocates memory with `malloc`, which never gets deallocated.

There is [rocksdb_writebatch_wi_destroy](https://github.com/facebook/rocksdb/blob/main/db/c.cc#L2174) but that tries to delete the memory allocated with malloc which is UB and tries to clear `rep`. Using `rocksdb_free` seems to be the right choice.  

### Extra allocations
There also seems to be unnecessary cloning of the serialized writebatch. The code clones the data once by calling `to_owned` on the slice but the data is also cloned here:
https://github.com/facebook/rocksdb/blob/main/db/c.cc#L1905

To improve that, I think we can just pass the `ptr` directly to `rocksdb_writebatch_create_from`