### PR TITLE
Add support for write buffer manager

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -32,6 +32,7 @@ fn rocksdb_include_dir() -> String {
 fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
         .header(rocksdb_include_dir() + "/rocksdb/c.h")
+        .header("rocks/c.h")
         .derive_debug(false)
         .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
@@ -52,6 +53,7 @@ fn build_rocksdb() {
     config.include("rocksdb/include/");
     config.include("rocksdb/");
     config.include("rocksdb/third-party/gtest-1.8.1/fused-src/");
+    config.include("rocks/");
 
     if cfg!(feature = "snappy") {
         config.define("SNAPPY", Some("1"));
@@ -254,7 +256,7 @@ fn build_rocksdb() {
     for file in lib_sources {
         config.file(format!("rocksdb/{file}"));
     }
-
+    config.file("rocks/write_buffer_manager.cc");
     config.file("build_version.cc");
 
     config.cpp(true);

--- a/librocksdb-sys/rocks/c.h
+++ b/librocksdb-sys/rocks/c.h
@@ -1,0 +1,32 @@
+// These functions are missing from upstream rocksdb/c.h
+// This should be upstreamed.
+#pragma once
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+    typedef struct rocksdb_options_t rocksdb_options_t;
+    /* write_buffer_manager */
+    typedef struct rocksdb_write_buffer_manager_t rocksdb_write_buffer_manager_t;
+    /* cache */
+    typedef struct rocksdb_cache_t rocksdb_cache_t;
+
+    void rocksdb_options_set_write_buffer_manager(rocksdb_options_t *opt, rocksdb_write_buffer_manager_t *manager);
+
+    /* write_buffer_manager */
+    rocksdb_write_buffer_manager_t *rocksdb_write_buffer_manager_create(size_t buffer_size);
+    rocksdb_write_buffer_manager_t *rocksdb_write_buffer_manager_create_with_cache(size_t buffer_size, rocksdb_cache_t *cache, bool allow_stall);
+
+    void rocksdb_write_buffer_manager_destroy(rocksdb_write_buffer_manager_t *manager);
+
+    unsigned char rocksdb_write_buffer_manager_enabled(rocksdb_write_buffer_manager_t *manager);
+    size_t rocksdb_write_buffer_manager_memory_usage(rocksdb_write_buffer_manager_t *manager);
+    size_t rocksdb_write_buffer_manager_buffer_size(rocksdb_write_buffer_manager_t *manager);
+#ifdef __cplusplus
+}
+#endif

--- a/librocksdb-sys/rocks/ctypes.hpp
+++ b/librocksdb-sys/rocks/ctypes.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <iostream>
+
+#include "rocksdb/options.h"
+#include "rocksdb/write_buffer_manager.h"
+#include "rocksdb/cache.h"
+
+using std::shared_ptr;
+
+using namespace ROCKSDB_NAMESPACE;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct rocksdb_options_t {
+  Options rep;
+};
+struct rocksdb_cache_t {
+  std::shared_ptr<Cache> rep;
+};
+/* write_buffer_manager */
+struct rocksdb_write_buffer_manager_t {
+  std::shared_ptr<WriteBufferManager> rep;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/librocksdb-sys/rocks/write_buffer_manager.cc
+++ b/librocksdb-sys/rocks/write_buffer_manager.cc
@@ -1,0 +1,36 @@
+#include "rocks/ctypes.hpp"
+
+using namespace ROCKSDB_NAMESPACE;
+
+using std::shared_ptr;
+
+extern "C" {
+void rocksdb_options_set_write_buffer_manager(rocksdb_options_t* opt, rocksdb_write_buffer_manager_t* manager) {
+  opt->rep.write_buffer_manager = manager->rep;
+}
+rocksdb_write_buffer_manager_t* rocksdb_write_buffer_manager_create(size_t buffer_size) {
+  auto manager = new rocksdb_write_buffer_manager_t;
+  manager->rep.reset(new WriteBufferManager(buffer_size));
+  return manager;
+}
+
+rocksdb_write_buffer_manager_t* rocksdb_write_buffer_manager_create_with_cache(size_t buffer_size, rocksdb_cache_t* cache,bool allow_stall){
+  auto manager = new rocksdb_write_buffer_manager_t;
+  manager->rep.reset(new WriteBufferManager(buffer_size, cache->rep, allow_stall));
+  return manager;
+}
+
+void rocksdb_write_buffer_manager_destroy(rocksdb_write_buffer_manager_t* manager) { delete manager; }
+
+unsigned char rocksdb_write_buffer_manager_enabled(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->enabled();
+}
+
+size_t rocksdb_write_buffer_manager_memory_usage(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->memory_usage();
+}
+
+size_t rocksdb_write_buffer_manager_buffer_size(rocksdb_write_buffer_manager_t* manager) {
+  return manager->rep->buffer_size();
+}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ mod snapshot;
 mod sst_file_writer;
 mod transactions;
 mod write_batch;
+mod write_buffer_manager;
 
 pub use crate::{
     column_family::{
@@ -131,6 +132,7 @@ pub use crate::{
         TransactionDBOptions, TransactionOptions,
     },
     write_batch::{WriteBatch, WriteBatchIterator, WriteBatchWithTransaction},
+    write_buffer_manager::WriteBufferManager,
 };
 
 use librocksdb_sys as ffi;
@@ -226,7 +228,7 @@ impl fmt::Display for Error {
 mod test {
     use crate::{
         OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, TransactionDB,
-        TransactionDBOptions, TransactionOptions,
+        TransactionDBOptions, TransactionOptions, WriteBufferManager,
     };
 
     use super::{
@@ -273,6 +275,7 @@ mod test {
         is_send::<TransactionDBOptions>();
         is_send::<OptimisticTransactionOptions>();
         is_send::<TransactionOptions>();
+        is_send::<WriteBufferManager>();
     }
 
     #[test]
@@ -303,5 +306,6 @@ mod test {
         is_sync::<TransactionDBOptions>();
         is_sync::<OptimisticTransactionOptions>();
         is_sync::<TransactionOptions>();
+        is_sync::<WriteBufferManager>();
     }
 }

--- a/src/write_buffer_manager.rs
+++ b/src/write_buffer_manager.rs
@@ -1,0 +1,134 @@
+///! `WriteBufferManager` is for managing memory allocation for one or more
+///! MemTables.
+use crate::{ffi, Cache};
+
+pub struct WriteBufferManager {
+    pub(crate) inner: *mut ffi::rocksdb_write_buffer_manager_t,
+}
+
+unsafe impl Send for WriteBufferManager {}
+unsafe impl Sync for WriteBufferManager {}
+
+impl Drop for WriteBufferManager {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_write_buffer_manager_destroy(self.inner);
+        }
+    }
+}
+
+impl WriteBufferManager {
+    /// _buffer_size = 0 indicates no limit.
+    pub fn new(buffer_size: usize) -> WriteBufferManager {
+        WriteBufferManager {
+            inner: unsafe { ffi::rocksdb_write_buffer_manager_create(buffer_size) },
+        }
+    }
+    // Parameters:
+    // _buffer_size: _buffer_size = 0 indicates no limit.
+
+    // cache_: if `cache` is provided, we'll put dummy entries in the cache and
+    // cost the memory allocated to the cache. It can be used even if _buffer_size
+    // = 0.
+    //
+    // allow_stall: if set true, it will enable stalling of writes when
+    // memory_usage() exceeds buffer_size. It will wait for flush to complete and
+    // memory usage to drop down.
+    pub fn new_with_cache(
+        buffer_size: usize,
+        cache: &Cache,
+        allow_stall: bool,
+    ) -> WriteBufferManager {
+        WriteBufferManager {
+            inner: unsafe {
+                ffi::rocksdb_write_buffer_manager_create_with_cache(
+                    buffer_size,
+                    cache.0.inner.as_ptr(),
+                    allow_stall,
+                )
+            },
+        }
+    }
+
+    // Returns true if buffer_limit is passed to limit the total memory usage and
+    // is greater than 0.
+    pub fn enabled(&self) -> bool {
+        unsafe { ffi::rocksdb_write_buffer_manager_enabled(self.inner) != 0 }
+    }
+
+    // Returns the total memory used by memtables if enabled.
+    pub fn memory_usage(&self) -> Option<usize> {
+        if self.enabled() {
+            Some(unsafe { ffi::rocksdb_write_buffer_manager_memory_usage(self.inner) })
+        } else {
+            None
+        }
+    }
+
+    // Returns the buffer_size.
+    pub fn buffer_size(&self) -> usize {
+        unsafe { ffi::rocksdb_write_buffer_manager_buffer_size(self.inner) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Options, DB};
+    use std::iter;
+    use tempfile::TempDir;
+
+    #[test]
+    fn write_buffer_manager_of_2db() {
+        let tmp_dir1 = TempDir::new().unwrap();
+        let tmp_dir2 = TempDir::new().unwrap();
+        let cache = Cache::new_lru_cache(10240);
+        let manager = WriteBufferManager::new_with_cache(102400, &cache, false);
+        let mut op1 = Options::default();
+        op1.create_if_missing(true);
+        op1.set_write_buffer_manager(&manager);
+        let mut op2 = Options::default();
+        op2.create_if_missing(true);
+        op2.set_write_buffer_manager(&manager);
+        assert_eq!(manager.memory_usage(), Some(0));
+        let db1 = DB::open(&op1, &tmp_dir1).unwrap();
+
+        let mem1 = manager.memory_usage().unwrap();
+
+        let db2 = DB::open(&op2, &tmp_dir2).unwrap();
+
+        assert_eq!(manager.enabled(), true);
+        let mem2 = manager.memory_usage().unwrap();
+        assert!(mem2 > mem1);
+
+        for i in 0..100 {
+            let key = format!("k{}", i);
+            let val = format!("v{}", i * i);
+            let value: String = iter::repeat(val).take(i * i).collect::<Vec<_>>().concat();
+
+            db1.put(key.as_bytes(), value.as_bytes()).unwrap();
+        }
+
+        let mem3 = manager.memory_usage().unwrap();
+        assert!(mem3 > mem2);
+
+        for i in 0..100 {
+            let key = format!("k{}", i);
+            let val = format!("v{}", i * i);
+            let value: String = iter::repeat(val).take(i * i).collect::<Vec<_>>().concat();
+
+            db2.put(key.as_bytes(), value.as_bytes()).unwrap();
+        }
+
+        let mem4 = manager.memory_usage().unwrap();
+        assert!(mem4 > mem3);
+
+        assert!(db2.flush().is_ok());
+        let mem5 = manager.memory_usage().unwrap();
+        assert!(mem5 < mem4);
+
+        drop(db1);
+        drop(db2);
+        assert_eq!(manager.memory_usage(), Some(0));
+    }
+}


### PR DESCRIPTION
Adds support for write buffer manager. All the c/ c++ code should be upstreamed. It's here because these functions are missing from [rocksdb/c.h](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/c.h)