### PR TITLE
BugFix: Skip looking for snappy if disabled

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -358,10 +358,12 @@ fn main() {
             println!("cargo:rustc-link-lib=dylib=stdc++");
         }
     }
-    if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
-        println!("cargo:rerun-if-changed=snappy/");
-        fail_on_empty_directory("snappy");
-        build_snappy();
+    if cfg!(feature = "snappy") {
+        if !try_to_find_and_link_lib("SNAPPY") {
+            println!("cargo:rerun-if-changed=snappy/");
+            fail_on_empty_directory("snappy");
+            build_snappy();
+        }
     }
 
     // Allow dependent crates to locate the sources and output directory of


### PR DESCRIPTION
Old logic would link snappy when not configured, but the lib was found via try_to_find_and_link_lib(). Results in contradictory Default=Snappy, Snappy=disabled state.

Ref: https://github.com/rust-rocksdb/rust-rocksdb/issues/799