### PR TITLE
Remove temporary boxed keys in batched_multi_get

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1173,23 +1173,23 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// Return the values associated with the given keys and the specified column family
     /// where internally the read requests are processed in batch if block-based table
     /// SST format is used.  It is a more optimized version of multi_get_cf.
-    pub fn batched_multi_get_cf<K, I>(
+    pub fn batched_multi_get_cf<'a, K, I>(
         &self,
         cf: &impl AsColumnFamilyRef,
         keys: I,
         sorted_input: bool,
     ) -> Vec<Result<Option<DBPinnableSlice>, Error>>
     where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]> + 'a + ?Sized,
+        I: IntoIterator<Item = &'a K>,
     {
         self.batched_multi_get_cf_opt(cf, keys, sorted_input, &ReadOptions::default())
     }
 
     /// Return the values associated with the given keys and the specified column family
     /// where internally the read requests are processed in batch if block-based table
-    /// SST format is used.  It is a more optimized version of multi_get_cf_opt.
-    pub fn batched_multi_get_cf_opt<K, I>(
+    /// SST format is used. It is a more optimized version of multi_get_cf_opt.
+    pub fn batched_multi_get_cf_opt<'a, K, I>(
         &self,
         cf: &impl AsColumnFamilyRef,
         keys: I,
@@ -1197,14 +1197,14 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         readopts: &ReadOptions,
     ) -> Vec<Result<Option<DBPinnableSlice>, Error>>
     where
-        K: AsRef<[u8]>,
-        I: IntoIterator<Item = K>,
+        K: AsRef<[u8]> + 'a + ?Sized,
+        I: IntoIterator<Item = &'a K>,
     {
-        let (keys, keys_sizes): (Vec<Box<[u8]>>, Vec<_>) = keys
+        let keys: Vec<&[u8]> = keys.into_iter().map(|k| k.as_ref()).collect::<Vec<_>>();
+        let (ptr_keys, keys_sizes): (Vec<_>, Vec<_>) = keys
             .into_iter()
-            .map(|k| (Box::from(k.as_ref()), k.as_ref().len()))
+            .map(|k| (k.as_ptr() as *const c_char, k.len()))
             .unzip();
-        let ptr_keys: Vec<_> = keys.iter().map(|k| k.as_ptr() as *const c_char).collect();
 
         let mut pinned_values = vec![ptr::null_mut(); ptr_keys.len()];
         let mut errors = vec![ptr::null_mut(); ptr_keys.len()];

--- a/src/db.rs
+++ b/src/db.rs
@@ -1200,10 +1200,12 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         K: AsRef<[u8]> + 'a + ?Sized,
         I: IntoIterator<Item = &'a K>,
     {
-        let keys: Vec<&[u8]> = keys.into_iter().map(|k| k.as_ref()).collect::<Vec<_>>();
         let (ptr_keys, keys_sizes): (Vec<_>, Vec<_>) = keys
             .into_iter()
-            .map(|k| (k.as_ptr() as *const c_char, k.len()))
+            .map(|k| {
+                let k = k.as_ref();
+                (k.as_ptr() as *const c_char, k.len())
+            })
             .unzip();
 
         let mut pinned_values = vec![ptr::null_mut(); ptr_keys.len()];


### PR DESCRIPTION
By forcing the caller to give us an iterator of key references, we can avoid having to clone and allocate one `Box` per input key in `batched_multi_get`, since the keys are already guaranteed to live longer than the function call.

This is a slight breaking change, but IMO an acceptable one which should make any users of `batched_multi_get` happy - the only reason to be using `batched_multi_get` in the first place is to avoid allocations, otherwise one would already use the simpler `multi_get`, which allocates for both keys and return values.

Examples of breaking changes:

```rust
let keys: Vec<String> = vec!["k0".to_string(), "k1".to_string()];
// NOT ALLOWED: owned `Vec` of owned keys
let _ = db.batched_multi_get_cf(&cf, keys, true)
// ALLOWED: borrowed `Vec` of owned keys (`&Vec<T>` impls `IntoIterator<Item=&T>`)
let _ = db.batched_multi_get_cf(&cf, &keys, true)
// ALLOWED: iterator of references to keys
let _ = db.batched_multi_get_cf(&cf, keys.iter().take(1), true)
```

```rust
// NOT ALLOWED: iterator of owned keys
let _ = db.batched_multi_get_cf(&cf, (0..4).map(|i| i.to_string()), true)
// need to collect into temporary then pass references
let keys = (0..4).map(|i| i.to_string()).collect::<Vec<_>>();
let _ = db.batched_multi_get_cf(&cf, &keys, true)  // or `keys.iter()`
```

```rust
// STILL ALLOWED: owned `Vec` of `&[u8]` keys
let keys: Vec<&[u8]> = vec![b"k0", b"k1", b"k2"];
let _ = db.batched_multi_get_cf(&cf, keys, true)
```