### PR TITLE
upgrade rustc to 1.71.0 in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: RocksDB CI
 
 on: [push, pull_request]
 env:
-  RUST_VERSION: 1.60.0
+  RUST_VERSION: 1.71.0
 
 jobs:
   fmt:


### PR DESCRIPTION
CI is failing because of a old rustc, see https://github.com/rust-rocksdb/rust-rocksdb/actions/runs/5745756916/job/15580442222?pr=808

```
error: package `linux-raw-sys v0.4.5` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.60.0
Error: Process completed with exit code 101.
```