### PR TITLE
Remove wrong outlive requirements for `Cache` in docs

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -398,7 +398,7 @@ impl BlockBasedOptions {
     }
 
     /// Sets global cache for blocks (user data is stored in a set of blocks, and
-    /// a block is the unit of reading from disk). Cache must outlive DB instance which uses it.
+    /// a block is the unit of reading from disk).
     ///
     /// If set, use the specified cache for blocks.
     /// By default, rocksdb will automatically create and use an 8MB internal cache.
@@ -2820,7 +2820,7 @@ impl Options {
         }
     }
 
-    /// Sets global cache for table-level rows. Cache must outlive DB instance which uses it.
+    /// Sets global cache for table-level rows.
     ///
     /// Default: null (disabled)
     /// Not supported in ROCKSDB_LITE mode!


### PR DESCRIPTION
Phrase `Cache must outlive DB instance which uses it.` was added to docs of `BlockBasedOptions::set_block_cache` and `Options::set_row_cache` in https://github.com/rust-rocksdb/rust-rocksdb/pull/446.

But this requirement for `Cache` methods argument should no longer be valid after https://github.com/rust-rocksdb/rust-rocksdb/pull/497 was merged because it:
> Wrap Cache and Env in an Rc and keep a copy of that in the database to ensure that they are not dropped before the database is.

I suggest to remove these outdated requirements from docs.

https://github.com/rust-rocksdb/rust-rocksdb/blob/b9932753d46bd7cc7eadfa0de7e1253ef0328ef1/src/db_options.rs#L401-L410

https://github.com/rust-rocksdb/rust-rocksdb/blob/b9932753d46bd7cc7eadfa0de7e1253ef0328ef1/src/db_options.rs#L2823-L2832

https://github.com/rust-rocksdb/rust-rocksdb/blob/b9932753d46bd7cc7eadfa0de7e1253ef0328ef1/src/db_options.rs#L50-L51

https://github.com/rust-rocksdb/rust-rocksdb/blob/b9932753d46bd7cc7eadfa0de7e1253ef0328ef1/src/db_options.rs#L38-L48
