### PR TITLE
Update RocksDB to 8.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde1 = ["serde"]
 
 [dependencies]
 libc = "0.2"
-librocksdb-sys = { path = "librocksdb-sys", version = "0.11.0" }
+librocksdb-sys = { path = "librocksdb-sys", version = "0.12.0" }
 serde = { version = "1", features = [ "derive" ], optional = true }
 
 [dev-dependencies]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "librocksdb-sys"
-version = "0.11.0+8.3.2"
+version = "0.12.0+8.5.3"
 edition = "2018"
 rust-version = "1.63"
 authors = ["Karl Hobley <karlhobley10@gmail.com>", "Arkadiy Paronyan <arkadiy@ethcore.io>"]

--- a/librocksdb-sys/build_version.cc
+++ b/librocksdb-sys/build_version.cc
@@ -8,17 +8,17 @@
 
 // The build script may replace these values with real values based
 // on whether or not GIT is available and the platform settings
-static const std::string rocksdb_build_git_sha  = "3f7c92b9753b697ce6a5ea737086d2751f17956c";
-static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.3.2";
+static const std::string rocksdb_build_git_sha  = "f32521662acf3352397d438b732144c7813bbbec";
+static const std::string rocksdb_build_git_tag = "rocksdb_build_git_tag:v8.5.3";
 #define HAS_GIT_CHANGES 0
 #if HAS_GIT_CHANGES == 0
 // If HAS_GIT_CHANGES is 0, the GIT date is used.
 // Use the time the branch/tag was last modified
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-06-15 05:32:14";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-09-01 20:58:39";
 #else
 // If HAS_GIT_CHANGES is > 0, the branch/tag has modifications.
 // Use the time the build was created.
-static const std::string rocksdb_build_date = "rocksdb_build_date:2023-06-15 05:32:14";
+static const std::string rocksdb_build_date = "rocksdb_build_date:2023-09-01 20:58:39";
 #endif
 
 std::unordered_map<std::string, ROCKSDB_NAMESPACE::RegistrarFunc> ROCKSDB_NAMESPACE::ObjectRegistry::builtins_ = {};

--- a/librocksdb-sys/rocksdb_lib_sources.txt
+++ b/librocksdb-sys/rocksdb_lib_sources.txt
@@ -243,6 +243,8 @@ util/stderr_logger.cc
 util/string_util.cc
 util/thread_local.cc
 util/threadpool_imp.cc
+util/udt_util.cc
+util/write_batch_util.cc
 util/xxhash.cc
 utilities/agg_merge/agg_merge.cc
 utilities/backup/backup_engine.cc

--- a/librocksdb-sys/tests/ffi.rs
+++ b/librocksdb-sys/tests/ffi.rs
@@ -1072,7 +1072,7 @@ fn ffi() {
                 rocksdb_slicetransform_create_fixed_prefix(3),
             );
             rocksdb_options_set_hash_skip_list_rep(options, 5000, 4, 4);
-            rocksdb_options_set_plain_table_factory(options, 4, 10, 0.75, 16);
+            rocksdb_options_set_plain_table_factory(options, 4, 10, 0.75, 16, 0, 0, 0, 0);
             rocksdb_options_set_allow_concurrent_memtable_write(options, 0);
 
             db = rocksdb_open(options, dbname, &mut err);

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2426,7 +2426,7 @@ impl Options {
     /// # Examples
     ///
     /// ```
-    /// use rocksdb::{EncodingType, Options, PlainTableFactoryOptions};
+    /// use rocksdb::{KeyEncodingType, Options, PlainTableFactoryOptions};
     ///
     /// let mut opts = Options::default();
     /// let factory_opts = PlainTableFactoryOptions {
@@ -2435,7 +2435,7 @@ impl Options {
     ///   hash_table_ratio: 0.75,
     ///   index_sparseness: 16,
     ///   huge_page_tlb_size: 0,
-    ///   encoding_type: EncodingType::Plain,
+    ///   encoding_type: KeyEncodingType::Plain,
     ///   full_scan_mode: false,
     ///   store_index_in_file: false,
     /// };
@@ -3606,11 +3606,17 @@ pub enum ChecksumType {
 
 /// Used in [`PlainTableFactoryOptions`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum EncodingType {
+pub enum KeyEncodingType {
     /// Always write full keys.
-    Plain,
+    Plain = 0,
     /// Find opportunities to write the same prefix for multiple rows.
-    Prefix,
+    Prefix = 1,
+}
+
+impl Default for KeyEncodingType {
+    fn default() -> Self {
+        KeyEncodingType::Plain
+    }
 }
 
 /// Used with DBOptions::set_plain_table_factory.
@@ -3622,13 +3628,17 @@ pub enum EncodingType {
 ///  bloom_bits_per_key: 10
 ///  hash_table_ratio: 0.75
 ///  index_sparseness: 16
+///  huge_page_tlb_size: 0
+///  encoding_type: KeyEncodingType::Plain
+///  full_scan_mode: false
+///  store_index_in_file: false
 pub struct PlainTableFactoryOptions {
     pub user_key_length: u32,
     pub bloom_bits_per_key: i32,
     pub hash_table_ratio: f64,
     pub index_sparseness: usize,
     pub huge_page_tlb_size: usize,
-    pub encoding_type: EncodingType,
+    pub encoding_type: KeyEncodingType,
     pub full_scan_mode: bool,
     pub store_index_in_file: bool,
 }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2446,6 +2446,10 @@ impl Options {
                 options.bloom_bits_per_key,
                 options.hash_table_ratio,
                 options.index_sparseness,
+                options.huge_page_tlb_size,
+                options.encoding_type as c_char,
+                c_uchar::from(options.full_scan_mode),
+                c_uchar::from(options.store_index_in_file),
             );
         }
     }
@@ -3596,6 +3600,15 @@ pub enum ChecksumType {
     XXH3 = 4, // Supported since RocksDB 6.27
 }
 
+/// Used in [`PlainTableFactoryOptions`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum EncodingType {
+    /// Always write full keys.
+    Plain,
+    /// Find opportunities to write the same prefix for multiple rows.
+    Prefix,
+}
+
 /// Used with DBOptions::set_plain_table_factory.
 /// See official [wiki](https://github.com/facebook/rocksdb/wiki/PlainTable-Format) for more
 /// information.
@@ -3610,6 +3623,10 @@ pub struct PlainTableFactoryOptions {
     pub bloom_bits_per_key: i32,
     pub hash_table_ratio: f64,
     pub index_sparseness: usize,
+    pub huge_page_tlb_size: usize,
+    pub encoding_type: EncodingType,
+    pub full_scan_mode: bool,
+    pub store_index_in_file: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2426,7 +2426,7 @@ impl Options {
     /// # Examples
     ///
     /// ```
-    /// use rocksdb::{Options, PlainTableFactoryOptions};
+    /// use rocksdb::{EncodingType, Options, PlainTableFactoryOptions};
     ///
     /// let mut opts = Options::default();
     /// let factory_opts = PlainTableFactoryOptions {
@@ -2434,6 +2434,10 @@ impl Options {
     ///   bloom_bits_per_key: 20,
     ///   hash_table_ratio: 0.75,
     ///   index_sparseness: 16,
+    ///   huge_page_tlb_size: 0,
+    ///   encoding_type: EncodingType::Plain,
+    ///   full_scan_mode: false,
+    ///   store_index_in_file: false,
     /// };
     ///
     /// opts.set_plain_table_factory(&factory_opts);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,10 @@ pub use crate::{
     db_options::{
         BlockBasedIndexType, BlockBasedOptions, BottommostLevelCompaction, Cache, ChecksumType,
         CompactOptions, CuckooTableOptions, DBCompactionStyle, DBCompressionType, DBPath,
-        DBRecoveryMode, DataBlockIndexType, EncodingType, FifoCompactOptions, FlushOptions,
-        IngestExternalFileOptions, LogLevel, MemtableFactory, Options, PlainTableFactoryOptions,
-        ReadOptions, UniversalCompactOptions, UniversalCompactionStopStyle, WriteOptions,
+        DBRecoveryMode, DataBlockIndexType, FifoCompactOptions, FlushOptions,
+        IngestExternalFileOptions, KeyEncodingType, LogLevel, MemtableFactory, Options,
+        PlainTableFactoryOptions, ReadOptions, UniversalCompactOptions,
+        UniversalCompactionStopStyle, WriteOptions,
     },
     db_pinnable_slice::DBPinnableSlice,
     env::Env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::{
     db_options::{
         BlockBasedIndexType, BlockBasedOptions, BottommostLevelCompaction, Cache, ChecksumType,
         CompactOptions, CuckooTableOptions, DBCompactionStyle, DBCompressionType, DBPath,
-        DBRecoveryMode, DataBlockIndexType, FifoCompactOptions, FlushOptions,
+        DBRecoveryMode, DataBlockIndexType, EncodingType, FifoCompactOptions, FlushOptions,
         IngestExternalFileOptions, LogLevel, MemtableFactory, Options, PlainTableFactoryOptions,
         ReadOptions, UniversalCompactOptions, UniversalCompactionStopStyle, WriteOptions,
     },

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -719,6 +719,7 @@ fn fifo_compaction_test() {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
+        opts.set_level_compaction_dynamic_level_bytes(false);
 
         // set compaction style
         {
@@ -844,6 +845,7 @@ fn get_with_cache_and_bulkload_test() {
     opts.set_db_log_dir(&log_path);
     opts.set_memtable_whole_key_filtering(true);
     opts.set_dump_malloc_stats(true);
+    opts.set_level_compaction_dynamic_level_bytes(false);
 
     // trigger all sst files in L1/2 instead of L0
     opts.set_max_bytes_for_level_base(64 << 10); // 64KB
@@ -979,6 +981,7 @@ fn get_with_cache_and_bulkload_and_blobs_test() {
     opts.set_dump_malloc_stats(true);
     opts.set_enable_blob_files(true);
     opts.set_min_blob_size(256); // set small to ensure it is actually used
+    opts.set_level_compaction_dynamic_level_bytes(false);
 
     // trigger all sst files in L1/2 instead of L0
     opts.set_max_bytes_for_level_base(64 << 10); // 64KB

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -20,8 +20,8 @@ use std::{mem, sync::Arc, thread, time::Duration};
 use pretty_assertions::assert_eq;
 
 use rocksdb::{
-    perf::get_memory_usage_stats, properties::STATS, BlockBasedOptions, BottommostLevelCompaction,
-    Cache, ColumnFamilyDescriptor, CompactOptions, CuckooTableOptions, DBAccess, DBCompactionStyle,
+    perf::get_memory_usage_stats, BlockBasedOptions, BottommostLevelCompaction, Cache,
+    ColumnFamilyDescriptor, CompactOptions, CuckooTableOptions, DBAccess, DBCompactionStyle,
     DBWithThreadMode, Env, Error, ErrorKind, FifoCompactOptions, IteratorMode, MultiThreaded,
     Options, PerfContext, PerfMetric, ReadOptions, SingleThreaded, SliceTransform, Snapshot,
     UniversalCompactOptions, UniversalCompactionStopStyle, WriteBatch, DB,

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -20,12 +20,11 @@ use std::{mem, sync::Arc, thread, time::Duration};
 use pretty_assertions::assert_eq;
 
 use rocksdb::{
-    perf::get_memory_usage_stats, BlockBasedOptions, BottommostLevelCompaction, Cache,
-    ColumnFamilyDescriptor, CompactOptions, CuckooTableOptions, DBAccess, DBCompactionStyle,
+    perf::get_memory_usage_stats, properties::STATS, BlockBasedOptions, BottommostLevelCompaction,
+    Cache, ColumnFamilyDescriptor, CompactOptions, CuckooTableOptions, DBAccess, DBCompactionStyle,
     DBWithThreadMode, Env, Error, ErrorKind, FifoCompactOptions, IteratorMode, MultiThreaded,
     Options, PerfContext, PerfMetric, ReadOptions, SingleThreaded, SliceTransform, Snapshot,
     UniversalCompactOptions, UniversalCompactionStopStyle, WriteBatch, DB,
-    properties::STATS,
 };
 use util::{assert_iter, pair, DBPath};
 
@@ -749,8 +748,6 @@ fn fifo_compaction_test() {
             let expect = format!("block_cache_hit_count = {block_cache_hit_count}");
             assert!(ctx.report(true).contains(&expect));
         }
-
-        println!("{}", db.property_value_cf(&cf1, STATS).unwrap().unwrap());
 
         // check live files (sst files meta)
         let livefiles = db.live_files().unwrap();

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -25,6 +25,7 @@ use rocksdb::{
     DBWithThreadMode, Env, Error, ErrorKind, FifoCompactOptions, IteratorMode, MultiThreaded,
     Options, PerfContext, PerfMetric, ReadOptions, SingleThreaded, SliceTransform, Snapshot,
     UniversalCompactOptions, UniversalCompactionStopStyle, WriteBatch, DB,
+    properties::STATS,
 };
 use util::{assert_iter, pair, DBPath};
 
@@ -749,11 +750,13 @@ fn fifo_compaction_test() {
             assert!(ctx.report(true).contains(&expect));
         }
 
+        println!("{}", db.property_value_cf(&cf1, STATS).unwrap().unwrap());
+
         // check live files (sst files meta)
         let livefiles = db.live_files().unwrap();
         assert_eq!(livefiles.len(), 1);
         livefiles.iter().for_each(|f| {
-            assert_eq!(f.level, 1);
+            assert_eq!(f.level, 6);
             assert_eq!(f.column_family_name, "cf1");
             assert!(!f.name.is_empty());
             assert_eq!(f.start_key.as_ref().unwrap().as_slice(), "k1".as_bytes());


### PR DESCRIPTION
Release: https://github.com/facebook/rocksdb/releases/tag/v8.5.3

Update mostly for bugfixes. Other changes because facebook/rocksdb@bfdc91017c0667e05cd2f2b49337446e0fb5c1b1 added additional arguments to `rocksdb_options_set_plain_table_factory`.