### PR TITLE
Expose `ReadTier` publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub use crate::{
         CompactOptions, CuckooTableOptions, DBCompactionStyle, DBCompressionType, DBPath,
         DBRecoveryMode, DataBlockIndexType, FifoCompactOptions, FlushOptions,
         IngestExternalFileOptions, KeyEncodingType, LogLevel, MemtableFactory, Options,
-        PlainTableFactoryOptions, ReadOptions, UniversalCompactOptions,
+        PlainTableFactoryOptions, ReadOptions, ReadTier, UniversalCompactOptions,
         UniversalCompactionStopStyle, WriteOptions,
     },
     db_pinnable_slice::DBPinnableSlice,


### PR DESCRIPTION
`ReadTier` isn't currently public but is required for `ReadOptions::set_read_tier` which is public.
This fixes that minor issue