### PR TITLE
fix: add raw iterator validation before calling next method

### DIFF
--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -289,15 +289,19 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
 
     /// Seeks to the next key.
     pub fn next(&mut self) {
-        unsafe {
-            ffi::rocksdb_iter_next(self.inner.as_ptr());
+        if self.valid() {
+            unsafe {
+                ffi::rocksdb_iter_next(self.inner.as_ptr());
+            }
         }
     }
 
     /// Seeks to the previous key.
     pub fn prev(&mut self) {
-        unsafe {
-            ffi::rocksdb_iter_prev(self.inner.as_ptr());
+        if self.valid() {
+            unsafe {
+                ffi::rocksdb_iter_prev(self.inner.as_ptr());
+            }
         }
     }
 

--- a/tests/test_raw_iterator.rs
+++ b/tests/test_raw_iterator.rs
@@ -136,3 +136,17 @@ pub fn test_seek_for_prev() {
         assert_item(&iter, b"k2", b"v2");
     }
 }
+
+#[test]
+pub fn test_next_without_seek() {
+    let n = DBPath::new("test_forgot_seek");
+    {
+        let db = DB::open_default(&n).unwrap();
+        db.put(b"k1", b"v1").unwrap();
+        db.put(b"k2", b"v2").unwrap();
+        db.put(b"k4", b"v4").unwrap();
+
+        let mut iter = db.raw_iterator();
+        iter.next();
+    }
+}


### PR DESCRIPTION
The PR fixes undefined behaviour described in the #824. 