### PR TITLE
feat: Expose set_auto_readahead_size

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3538,6 +3538,15 @@ impl ReadOptions {
         }
     }
 
+    /// Automatically trim readahead size when iterating with an upper bound.
+    ///
+    /// Default: `false`
+    pub fn set_auto_readahead_size(&mut self, v: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_auto_readahead_size(self.inner, c_uchar::from(v));
+        }
+    }
+
     /// If true, create a tailing iterator. Note that tailing iterators
     /// only support moving in the forward direction. Iterating in reverse
     /// or seek_to_last are not supported.


### PR DESCRIPTION
From [RocksDB 8.6.0](https://github.com/facebook/rocksdb/blob/main/HISTORY.md#860-08182023):

> Add a new feature to trim readahead_size during scans upto upper_bound when iterate_upper_bound is specified. It's enabled through ReadOptions.auto_readahead_size. Users must also specify ReadOptions.iterate_upper_bound.