### PR TITLE
Make `CompactOptions` `Send` and `Sync`

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -282,6 +282,7 @@ unsafe impl Send for CuckooTableOptions {}
 unsafe impl Send for ReadOptions {}
 unsafe impl Send for IngestExternalFileOptions {}
 unsafe impl Send for CacheWrapper {}
+unsafe impl Send for CompactOptions {}
 
 // Sync is similarly safe for many types because they do not expose interior mutability, and their
 // use within the rocksdb library is generally behind a const reference
@@ -292,6 +293,7 @@ unsafe impl Sync for CuckooTableOptions {}
 unsafe impl Sync for ReadOptions {}
 unsafe impl Sync for IngestExternalFileOptions {}
 unsafe impl Sync for CacheWrapper {}
+unsafe impl Sync for CompactOptions {}
 
 impl Drop for Options {
     fn drop(&mut self) {


### PR DESCRIPTION
Like the other database option types, it is safe to send and sync this type.