### PR TITLE
update doc and arg name for optimize_for_point_lookup

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1581,9 +1581,12 @@ impl Options {
         }
     }
 
-    pub fn optimize_for_point_lookup(&mut self, cache_size: u64) {
+    // Use this if you don't need to keep the data sorted, i.e. you'll never use
+    // an iterator, only Put() and Get() API calls
+    //
+    pub fn optimize_for_point_lookup(&mut self, block_cache_size_mb: u64) {
         unsafe {
-            ffi::rocksdb_options_optimize_for_point_lookup(self.inner, cache_size);
+            ffi::rocksdb_options_optimize_for_point_lookup(self.inner, block_cache_size_mb);
         }
     }
 


### PR DESCRIPTION
Current `optimize_for_point_lookup ` has no documentation and has a confusing `cache_size` arg.
This pr copies the [comment from rocksdb](https://github.com/facebook/rocksdb/blob/36704e9227a355fcb8b10bd6d29cf0f9f43d80f8/include/rocksdb/options.h#L83) and renamed the `cache_size` to `block_cache_size_mb` for consistency and clarity.