### PR TITLE
Ensure non-null pointers for `ptr::copy_nonoverlapping`

### DIFF
--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -300,8 +300,8 @@ impl<T: ThreadMode> TransactionDB<T> {
             let mut cnt = 0;
             let ptr = ffi::rocksdb_transactiondb_get_prepared_transactions(db, &mut cnt);
             let mut vec = vec![std::ptr::null_mut(); cnt];
-            std::ptr::copy_nonoverlapping(ptr, vec.as_mut_ptr(), cnt);
             if !ptr.is_null() {
+                std::ptr::copy_nonoverlapping(ptr, vec.as_mut_ptr(), cnt);
                 ffi::rocksdb_free(ptr as *mut c_void);
             }
             vec


### PR DESCRIPTION
This PR aims to resolve an issue encountered when using the nightly toolchain for building. An error arises indicating a violation of the safety precondition for `ptr::copy_nonoverlapping`. Although the documentation for [`ptr::copy_nonoverlapping`](https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html#safety) does not explicitly state that the `src` pointer needs to be non-null, the implementation mandates it. This issue appears to stem from the changes introduced by https://github.com/rust-lang/rust/pull/121662.

Here's the stderr using `nightly-2024-03-12` toolchain:

```stderr
thread 'main' panicked at library/core/src/panicking.rs:156:5:
unsafe precondition(s) violated: ptr::copy_nonoverlapping requires that both pointer arguments are aligned and non-null and the specified memory ranges do not overlap

   0:        0x10f09d365 - std::backtrace_rs::backtrace::libunwind::trace::hab7b5e4615e8b18c
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/../../backtrace/src/backtrace/libunwind.rs:104:5
   1:        0x10f09d365 - std::backtrace_rs::backtrace::trace_unsynchronized::hc6ad71b7e980e9e6
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x10f09d365 - std::sys_common::backtrace::_print_fmt::h4da31242d01adac6
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/sys_common/backtrace.rs:68:5
   3:        0x10f09d365 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h18c82148567fc9d8
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/sys_common/backtrace.rs:44:22
   4:        0x10f0c1a0b - core::fmt::rt::Argument::fmt::h3af6fbd0a6eef702
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/fmt/rt.rs:142:9
   5:        0x10f0c1a0b - core::fmt::write::h9eb917e69949c790
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/fmt/mod.rs:1120:17
   6:        0x10f0997fe - std::io::Write::write_fmt::hc31681720cec56d4
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/io/mod.rs:1846:15
   7:        0x10f09d121 - std::sys_common::backtrace::_print::h9d8ccd172f7b38f5
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/sys_common/backtrace.rs:47:5
   8:        0x10f09d121 - std::sys_common::backtrace::print::hfb78c7405188153b
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/sys_common/backtrace.rs:34:9
   9:        0x10f09e649 - std::panicking::default_hook::{{closure}}::hc47ada15a7df520a
  10:        0x10f09e3b4 - std::panicking::default_hook::ha35bd2674736e44a
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/panicking.rs:292:9
  11:        0x10f09f07e - std::panicking::rust_panic_with_hook::h172c976b802885bd
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/panicking.rs:779:13
  12:        0x10f09e9ac - std::panicking::begin_panic_handler::{{closure}}::he7a23e51c212e898
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/panicking.rs:649:13
  13:        0x10f09d859 - std::sys_common::backtrace::__rust_end_short_backtrace::h17ca4edce2ff0942
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/sys_common/backtrace.rs:171:18
  14:        0x10f09e716 - rust_begin_unwind
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/std/src/panicking.rs:645:5
  15:        0x10f0fa3ba - core::panicking::panic_nounwind_fmt::runtime::h2b542cb4f67bfcea
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/panicking.rs:110:18
  16:        0x10f0fa3ba - core::panicking::panic_nounwind_fmt::h930bd381faad2f11
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/panicking.rs:122:9
  17:        0x10f0fa46d - core::panicking::panic_nounwind::h871b2437ae07f257
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/panicking.rs:155:5
  18:        0x10ead8f10 - core::intrinsics::copy_nonoverlapping::precondition_check::he8739c283a12aa87
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/intrinsics.rs:2752:21
  19:        0x10ead57d5 - core::intrinsics::copy_nonoverlapping::hab70b7de5ae01afe
                               at /rustc/878c8a2a62d49ca5c454547ad67290a1df746cb5/library/core/src/intrinsics.rs:2898:9
  20:        0x10ead57d5 - rocksdb::transactions::transaction_db::TransactionDB<T>::open_cf_descriptors_internal::h55b164cd50c8ab2f
                               at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocksdb-0.22.0/src/transactions/transaction_db.rs:303:13
  21:        0x10ead5dc1 - rocksdb::transactions::transaction_db::TransactionDB<T>::open_cf::hd6becb6c53c14700
                               at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rocksdb-0.22.0/src/transactions/transaction_db.rs:200:9
```