### PR TITLE
Make BackupEngine Send

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -48,6 +48,10 @@ pub struct RestoreOptions {
     inner: *mut ffi::rocksdb_restore_options_t,
 }
 
+// BackupEngine is a simple pointer wrapper, so it's safe to send to another thread
+// since the underlying RocksDB backup engine is thread-safe.
+unsafe impl Send for BackupEngine {}
+
 impl BackupEngine {
     /// Open a backup engine with the specified options and RocksDB Env.
     pub fn open(opts: &BackupEngineOptions, env: &Env) -> Result<Self, Error> {

--- a/tests/test_backup.rs
+++ b/tests/test_backup.rs
@@ -107,3 +107,10 @@ fn restore_from_backup() {
         }
     }
 }
+
+fn assert_send_generic<T: Send>() {}
+
+#[test]
+fn assert_send() {
+    assert_send_generic::<BackupEngine>();
+}


### PR DESCRIPTION
BackupEngine is a simple pointer wrapper, so it's safe to send to another thread since the underlying RocksDB backup engine is thread-safe.