### PR TITLE
Add linking libatomic command to build.rs to allow building for riscv64gc-unknown-linux-gnu target

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -252,7 +252,10 @@ fn build_rocksdb() {
         config.flag("-Wno-strict-aliasing");
         config.flag("-Wno-invalid-offsetof");
     }
-
+    if target.contains("riscv64gc") {
+        // link libatomic required to build for riscv64gc
+        println!("cargo:rustc-link-lib=atomic");
+    }
     for file in lib_sources {
         config.file(format!("rocksdb/{file}"));
     }


### PR DESCRIPTION
When building for the riscv64gc-unknown-linux-gnu target I was getting the link-time error 

```
error: linking with `riscv64-linux-gnu-g++` failed: exit status: 1

...

undefined reference to `__atomic_compare_exchange_1'
```

This is fixed by adding the following to the build.rs