### PR TITLE
build: 💐 incremental builds are idempotent

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -53,6 +53,19 @@ fn bindgen_rocksdb() {
 }
 
 fn build_rocksdb() {
+    /// The name of the compiled library.
+    const ARCHIVE: &str = "librocksdb.a";
+
+    // Check if rocksdb has already been built.
+    if env::var("OUT_DIR")
+        .map(PathBuf::from)
+        .unwrap()
+        .join(ARCHIVE)
+        .exists()
+    {
+        return;
+    }
+
     let target = env::var("TARGET").unwrap();
 
     let mut config = cc::Build::new();
@@ -267,7 +280,7 @@ fn build_rocksdb() {
 
     config.cpp(true);
     config.flag_if_supported("-std=c++17");
-    config.compile("librocksdb.a");
+    config.compile(ARCHIVE);
 }
 
 fn build_snappy() {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -284,6 +284,19 @@ fn build_rocksdb() {
 }
 
 fn build_snappy() {
+    /// The name of the compiled library.
+    const ARCHIVE: &str = "libsnappy.a";
+
+    // Check if snappy has already been built.
+    if env::var("OUT_DIR")
+        .map(PathBuf::from)
+        .unwrap()
+        .join(ARCHIVE)
+        .exists()
+    {
+        return;
+    }
+
     let target = env::var("TARGET").unwrap();
     let endianness = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
     let mut config = cc::Build::new();
@@ -312,7 +325,7 @@ fn build_snappy() {
     config.file("snappy/snappy-sinksource.cc");
     config.file("snappy/snappy-c.cc");
     config.cpp(true);
-    config.compile("libsnappy.a");
+    config.compile(ARCHIVE);
 }
 
 fn try_to_find_and_link_lib(lib_name: &str) -> bool {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -30,18 +30,25 @@ fn rocksdb_include_dir() -> String {
 }
 
 fn bindgen_rocksdb() {
-    let bindings = bindgen::Builder::default()
+    let out_path = env::var("OUT_DIR")
+        .map(PathBuf::from)
+        .unwrap()
+        .join("bindings.rs");
+
+    // Check if the bindings to rocksdb have already been generated.
+    if out_path.exists() {
+        return;
+    }
+
+    bindgen::Builder::default()
         .header(rocksdb_include_dir() + "/rocksdb/c.h")
         .derive_debug(false)
         .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
         .ctypes_prefix("libc")
         .size_t_is_usize(true)
         .generate()
-        .expect("unable to generate rocksdb bindings");
-
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
+        .expect("unable to generate rocksdb bindings")
+        .write_to_file(out_path)
         .expect("unable to write rocksdb bindings");
 }
 


### PR DESCRIPTION
this branch makes a collection of small tweaks to the `librocksdb-sys` crate's
build script. these changes improve incremental builds of the library, by
adding conditional early returns that check if the rocksdb bindings, rocksdb
library, and snappy library have already been generated or compiled.

currently, repeated builds of the `librocksdb-sys` library are never considered
fresh. for projects that rely on rocksdb as backing storage, this can create
a bottleneck in builds, and lead to spuriously recompiling dependent libraries.
