### PR TITLE
toolchain: 📌 pin toolchain to rust `1.70.0`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.70.0"


### PR DESCRIPTION
in CI, we specify the rust version as 1.70.0...

```yaml
on: [push, pull_request]
env:
  RUST_VERSION: 1.70.0
```

likewise, the package manifest pins the rust version...

```toml
rust-version = "1.70.0"
```

..but this version is not pinned by cargo, via a `rust-toolchain`. this means that testing this project using the stable toolchain by default (_at time of writing, this is 1.78.0_) will see test failures due to error messages not matching the expected snapshots, due to `rustc` itself making changes to its diagnostics:

```
test tests/fail/snapshot_outlive_db.rs ... mismatch

EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0597]: `db` does not live long enough
 --> tests/fail/snapshot_outlive_db.rs:6:9
  |
4 |     let _snapshot = {
  |         --------- borrow later stored here
5 |         let db = DB::open_default("foo").unwrap();
  |             -- binding `db` declared here
6 |         db.snapshot()
  |         ^^^^^^^^^^^^^ borrowed value does not live long enough
7 |     };
  |     - `db` dropped here while still borrowed
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error[E0597]: `db` does not live long enough
 --> tests/fail/snapshot_outlive_db.rs:6:9
  |
4 |     let _snapshot = {
  |         --------- borrow later stored here
5 |         let db = DB::open_default("foo").unwrap();
  |             -- binding `db` declared here
6 |         db.snapshot()
  |         ^^ borrowed value does not live long enough
7 |     };
  |     - `db` dropped here while still borrowed
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
note: If the actual output is the correct output you can bless it by rerunning
      your test with the environment variable TRYBUILD=overwrite
```

this commit introduces a `rust-toolchain.toml` file so that the correct version of rust is used by those building or contributing to this project.