### PR TITLE
Bump lz4 1.10

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -28,7 +28,7 @@ rtti = []
 [dependencies]
 libc = "0.2"
 tikv-jemalloc-sys = { version = "0.5", features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
-lz4-sys = { version = "1.9", optional = true }
+lz4-sys = { version = "1.10", optional = true }
 zstd-sys = { version = "2.0", features = ["zdict_builder"], optional = true }
 libz-sys = { version = "1.1", default-features = false, optional = true }
 bzip2-sys = { version = "0.1", default-features = false, optional = true }


### PR DESCRIPTION
A new version of LZ4 is out.

- https://github.com/lz4/lz4/releases/tag/v1.10.0
- https://crates.io/crates/lz4-sys/1.10.0