### PR TITLE
Implement `Sync` for `{Bound}ColumnFamily`

### DIFF
--- a/src/column_family.rs
+++ b/src/column_family.rs
@@ -146,6 +146,8 @@ impl<'a> AsColumnFamilyRef for Arc<BoundColumnFamily<'a>> {
 }
 
 unsafe impl Send for ColumnFamily {}
+unsafe impl Sync for ColumnFamily {}
 unsafe impl Send for UnboundColumnFamily {}
 unsafe impl Sync for UnboundColumnFamily {}
 unsafe impl<'a> Send for BoundColumnFamily<'a> {}
+unsafe impl<'a> Sync for BoundColumnFamily<'a> {}


### PR DESCRIPTION
See https://github.com/rust-rocksdb/rust-rocksdb/issues/407#issuecomment-1635967796 for justification on safety. This is a significant blocker to multi-threaded code.

closes #407