### PR TITLE
Fix two tests that want to write to the current working directory

### DIFF
--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -158,7 +158,11 @@ fn test_filter(level: u32, key: &[u8], value: &[u8]) -> Decision {
 fn compaction_filter_test() {
     use crate::{Options, DB};
 
-    let path = "_rust_rocksdb_filter_test";
+    let tempdir = tempfile::Builder::new()
+        .prefix("_rust_rocksdb_filter_test")
+        .tempdir()
+        .expect("Failed to create temporary path for the _rust_rocksdb_filter_test");
+    let path = tempdir.path();
     let mut opts = Options::default();
     opts.create_if_missing(true);
     opts.set_compaction_filter("test", test_filter);

--- a/src/compaction_filter_factory.rs
+++ b/src/compaction_filter_factory.rs
@@ -122,7 +122,11 @@ mod tests {
 
     #[test]
     fn compaction_filter_factory_test() {
-        let path = "_rust_rocksdb_filter_factory_test";
+        let tempdir = tempfile::Builder::new()
+            .prefix("_rust_rocksdb_filter_factory_test")
+            .tempdir()
+            .expect("Failed to create temporary path for the _rust_rocksdb_filter_factory_test.");
+        let path = tempdir.path();
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_compaction_filter_factory(TestFactory(CString::new("TestFactory").unwrap()));


### PR DESCRIPTION
I needed this patch for the Debian package of the `rocksdb` crate, as when we run the tests the current working directory is not writable.

I'm not a Rust developer at all, please let me know if there is a better way to do this.

Thank you!