### PR TITLE
Fix column family creation race.

### DIFF
--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -994,8 +994,11 @@ impl TransactionDB<SingleThreaded> {
 impl TransactionDB<MultiThreaded> {
     /// Creates column family with given name and options.
     pub fn create_cf<N: AsRef<str>>(&self, name: N, opts: &Options) -> Result<(), Error> {
+        // Note that we acquire the cfs lock before inserting: otherwise we might race
+        // another caller who observed the handle as missing.
+        let mut cfs = self.cfs.cfs.write().unwrap();
         let inner = self.create_inner_cf_handle(name.as_ref(), opts)?;
-        self.cfs.cfs.write().unwrap().insert(
+        cfs.insert(
             name.as_ref().to_string(),
             Arc::new(UnboundColumnFamily { inner }),
         );


### PR DESCRIPTION
When callers are executing code like:
```rust
// Check if the column family already exists.
if let Some(cf) = self.borrow_db().cf_handle(state_type) {
    return Ok(cf);
}

// Create the column family if it doesn't exist.
let create_result = block_in_place(|| {
    self.borrow_db()
        .create_cf(state_type, &create_column_family_options())
});
```
...they might reasonably expect that if the call fails with `InvalidArgument`, and the reason for the `InvalidArgument` was "Column family already exists", then upon retrying like so:
```rust
match create_result {
  Ok(()) => (),
  Err(e) => {
    if e.kind() == rocksdb::ErrorKind::InvalidArgument {
      // We might have lost a race to create the column family.
      if let Some(cf) = self.borrow_db().cf_handle(state_type) {
        return Ok(cf);
      }
    }
    return Err(format!(
        "Failed to create column family for state type '{state_type}': {e}"
    ));
  }
}
```
...that they would be able to observe the newly created column family.

But because of the order of locking for `MultiThreaded` access, the column family might not be observable via `cf_handle` yet (likely because the writer is still waiting to acquire the lock).

----

This change acquires the write lock _around_ the creation of the column family, so that a call which fails due to "already exists" should always be able to observe the created column family afterward.