### PR TITLE
fix(build): add ROCKSDB_SCHED_GETCPU_PRESENT for Linux build config

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -162,7 +162,7 @@ fn build_rocksdb() {
         config.define("OS_LINUX", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);
         config.define("ROCKSDB_LIB_IO_POSIX", None);
-	    config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
+        config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
     } else if target.contains("dragonfly") {
         config.define("OS_DRAGONFLYBSD", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -162,6 +162,7 @@ fn build_rocksdb() {
         config.define("OS_LINUX", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);
         config.define("ROCKSDB_LIB_IO_POSIX", None);
+	    config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
     } else if target.contains("dragonfly") {
         config.define("OS_DRAGONFLYBSD", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);


### PR DESCRIPTION
This change adds a define for ROCKSDB_SCHED_GETCPU_PRESENT in the Linux-specific section of the build script. This ensures that the RocksDB library is aware of the presence of the sched_getcpu function on Linux systems, potentially optimizing CPU scheduling.