### PR TITLE
Options: Add set_track_and_verify_wals_in_manifest

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3538,7 +3538,7 @@ impl Options {
     /// etc. or writing with `WriteOptions::sync=true` to sync the live WAL is not
     /// tracked for performance/efficiency reasons.
     ///
-    /// See: https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST
+    /// See: <https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST>
     ///
     /// Default: false (disabled)
     pub fn set_track_and_verify_wals_in_manifest(&mut self, val: bool) {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3524,6 +3524,35 @@ impl Options {
             ffi::rocksdb_options_set_avoid_unnecessary_blocking_io(self.inner, u8::from(val));
         }
     }
+
+    /// If true, the log numbers and sizes of the synced WALs are tracked
+    /// in MANIFEST. During DB recovery, if a synced WAL is missing
+    /// from disk, or the WAL's size does not match the recorded size in
+    /// MANIFEST, an error will be reported and the recovery will be aborted.
+    ///
+    /// This is one additional protection against WAL corruption besides the
+    /// per-WAL-entry checksum.
+    ///
+    /// Note that this option does not work with secondary instance.
+    /// Currently, only syncing closed WALs are tracked. Calling `DB::SyncWAL()`,
+    /// etc. or writing with `WriteOptions::sync=true` to sync the live WAL is not
+    /// tracked for performance/efficiency reasons.
+    ///
+    /// See: https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST
+    ///
+    /// Default: false (disabled)
+    pub fn set_track_and_verify_wals_in_manifest(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_track_and_verify_wals_in_manifest(self.inner, u8::from(val));
+        }
+    }
+
+    /// Returns the value of the `track_and_verify_wals_in_manifest` option.
+    pub fn get_track_and_verify_wals_in_manifest(&self) -> bool {
+        let val_u8 =
+            unsafe { ffi::rocksdb_options_get_track_and_verify_wals_in_manifest(self.inner) };
+        val_u8 != 0
+    }
 }
 
 impl Default for Options {

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -281,6 +281,27 @@ fn test_set_avoid_unnecessary_blocking_io() {
 }
 
 #[test]
+fn test_set_track_and_verify_wals_in_manifest() {
+    let path = DBPath::new("_set_track_and_verify_wals_in_manifest");
+
+    // test the defaults and the setter/accessor
+    let mut opts = Options::default();
+    assert!(!opts.get_track_and_verify_wals_in_manifest());
+    opts.set_track_and_verify_wals_in_manifest(true);
+    assert!(opts.get_track_and_verify_wals_in_manifest());
+    opts.set_track_and_verify_wals_in_manifest(false);
+    assert!(!opts.get_track_and_verify_wals_in_manifest());
+
+    // verify that a database created with this option works
+    // TODO: Check that the MANIFEST actually contains WalAddition/WalDeletion records
+    opts.create_if_missing(true);
+    opts.set_track_and_verify_wals_in_manifest(true);
+    let db = DB::open(&opts, &path).unwrap();
+    db.put(b"k1", b"a").expect("put must work");
+    assert_eq!(db.get(b"k1").unwrap().unwrap(), b"a");
+}
+
+#[test]
 fn test_set_periodic_compaction_seconds() {
     let path = DBPath::new("_set_periodic_compaction_seconds");
     {


### PR DESCRIPTION
This was added to the C API in RocksDB 9.7.0. The RocksDB wiki recommends setting this option to true:

"We recommend to set track_and_verify_wals_in_manifest to true for production, it has been enabled in production for the entire database cluster serving the social graph for all Meta apps."

See: https://github.com/facebook/rocksdb/wiki/Track-WAL-in-MANIFEST