### PR TITLE
DB: Implement get_db_identity using rocksdb_get_db_identity

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3524,6 +3524,30 @@ impl Options {
             ffi::rocksdb_options_set_avoid_unnecessary_blocking_io(self.inner, u8::from(val));
         }
     }
+
+    /// The DB unique ID can be saved in the DB manifest (preferred, this option)
+    /// or an IDENTITY file (historical, deprecated), or both. If this option is
+    /// set to false (old behavior), then `write_identity_file` must be set to true.
+    /// The manifest is preferred because
+    /// 1. The IDENTITY file is not checksummed, so it is not as safe against
+    ///    corruption.
+    /// 2. The IDENTITY file may or may not be copied with the DB (e.g. not
+    ///    copied by BackupEngine), so is not reliable for the provenance of a DB.
+    /// This option might eventually be obsolete and removed as Identity files
+    /// are phased out.
+    ///
+    /// Default: true (enabled)
+    pub fn set_write_dbid_to_manifest(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_write_dbid_to_manifest(self.inner, u8::from(val));
+        }
+    }
+
+    /// Returns the value of the `write_dbid_to_manifest` option.
+    pub fn get_write_dbid_to_manifest(&self) -> bool {
+        let val_u8 = unsafe { ffi::rocksdb_options_get_write_dbid_to_manifest(self.inner) };
+        val_u8 != 0
+    }
 }
 
 impl Default for Options {

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -16,6 +16,7 @@ mod util;
 
 use std::{fs, io::Read as _};
 
+use rocksdb::checkpoint::Checkpoint;
 use rocksdb::{
     BlockBasedOptions, Cache, DBCompressionType, DataBlockIndexType, Env, LruCacheOptions, Options,
     ReadOptions, DB,
@@ -366,4 +367,38 @@ fn test_lru_cache_custom_opts() {
 
     // Cache hit
     assert_eq!(&*db.get(KEY).unwrap().unwrap(), VALUE);
+}
+
+#[test]
+fn test_set_write_dbid_to_manifest() {
+    let path = DBPath::new("_set_write_dbid_to_manifest");
+
+    // test the defaults and the setter/accessor
+    let mut opts = Options::default();
+    assert!(opts.get_write_dbid_to_manifest());
+    opts.set_write_dbid_to_manifest(false);
+    assert!(!opts.get_write_dbid_to_manifest());
+    opts.set_write_dbid_to_manifest(true);
+    assert!(opts.get_write_dbid_to_manifest());
+
+    // verify the DBID is preserved across checkpoints. If set to false this is not true
+    opts.create_if_missing(true);
+    opts.set_write_dbid_to_manifest(true);
+    let db_orig = DB::open(&opts, &path).unwrap();
+    let db_orig_id = db_orig.get_db_identity().unwrap();
+
+    // a checkpoint from this database has the SAME DBID if it is in the manifest
+    let checkpoint_path = DBPath::new("set_write_dbid_checkpoint");
+    let checkpoint = Checkpoint::new(&db_orig).unwrap();
+    checkpoint.create_checkpoint(&checkpoint_path).unwrap();
+
+    let db_checkpoint = DB::open(&opts, &checkpoint_path).unwrap();
+    let db_checkpoint_id = db_checkpoint.get_db_identity().unwrap();
+    assert_eq!(
+        db_orig_id,
+        db_checkpoint_id,
+        "expected database identity to be preserved across checkpoints; db_orig={} db_checkpoint={}",
+        String::from_utf8_lossy(&db_orig_id),
+        String::from_utf8_lossy(&db_checkpoint_id)
+    );
 }


### PR DESCRIPTION
This exposes the rocksdb_get_db_identity function, which calls DB::GetDbIdentity. It also adds a setter and accessor to Options to change the option.

This function is useful to determine if two RocksDB copies originated from the same place.