### PR TITLE
 typo fix Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,7 +502,7 @@
 * Cleaned up and improved coverage and tests of the ffi module (alexreg)
 * Added many new methods to the `Options` type (development by ngaut, BusyJay, zhangjinpeng1987, siddontang and hhkbp2. ported by kaedroho)
 * Added `len` and `is_empty` methods to `WriteBatch` (development by siddontang. ported by kaedroho)
-* Added `path` mathod to `DB` (development by siddontang. ported by kaedroho)
+* Added `path` method to `DB` (development by siddontang. ported by kaedroho)
 * `DB::open` now accepts any type that implements `Into<Path>` as the path argument (kaedroho)
 * `DB` now implements the `Debug` trait (kaedroho)
 * Add iterator_cf to snapshot (jezell)


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `CHANGELOG.md`**

## Description  
This pull request corrects a minor typo in the `CHANGELOG.md` file. The word "mathod" has been updated to "method" for clarity and accuracy.

### Changes Made:
- **File Modified:** `CHANGELOG.md`
- **Summary of Changes:**  
  - Corrected "mathod" to "method" in the description of `path` for the `DB` type.

## Checklist  
- [x] Grammar correction in documentation.
- [x] Verified the change does not impact the changelog's semantic meaning.

## Additional Notes  
This is a documentation-only update aimed at improving clarity and professionalism in the project's changelog.

---

**Allow edits by maintainers:** [x]
