### PR TITLE
Fix future clippy warnings

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -263,7 +263,7 @@ fn build_rocksdb() {
         config.flag("-EHsc");
         config.flag("-std:c++17");
     } else {
-        config.flag(&cxx_standard());
+        config.flag(cxx_standard());
         // matches the flags in CMakeLists.txt from rocksdb
         config.flag("-Wsign-compare");
         config.flag("-Wshadow");

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -134,7 +134,6 @@ impl BackupEngine {
     ///     return Err(e.to_string());
     ///  }
     /// ```
-
     pub fn restore_from_latest_backup<D: AsRef<Path>, W: AsRef<Path>>(
         &mut self,
         db_dir: D,

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -66,7 +66,7 @@ impl<'db> Checkpoint<'db> {
     }
 }
 
-impl<'db> Drop for Checkpoint<'db> {
+impl Drop for Checkpoint<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_checkpoint_object_destroy(self.inner);

--- a/src/column_family.rs
+++ b/src/column_family.rs
@@ -138,7 +138,7 @@ impl Drop for ColumnFamily {
 
 // these behaviors must be identical between BoundColumnFamily and UnboundColumnFamily
 // due to the unsafe transmute() in bound_column_family()!
-impl<'a> Drop for BoundColumnFamily<'a> {
+impl Drop for BoundColumnFamily<'_> {
     fn drop(&mut self) {
         destroy_handle(self.inner);
     }
@@ -170,7 +170,7 @@ impl AsColumnFamilyRef for ColumnFamily {
     }
 }
 
-impl<'a> AsColumnFamilyRef for &'a ColumnFamily {
+impl AsColumnFamilyRef for &'_ ColumnFamily {
     fn inner(&self) -> *mut ffi::rocksdb_column_family_handle_t {
         self.inner
     }
@@ -181,7 +181,7 @@ impl<'a> AsColumnFamilyRef for &'a ColumnFamily {
 // isn't expected to be used as naked.
 // Also, ColumnFamilyRef might not be Arc<BoundColumnFamily<'a>> depending crate
 // feature flags so, we can't use the type alias here.
-impl<'a> AsColumnFamilyRef for Arc<BoundColumnFamily<'a>> {
+impl AsColumnFamilyRef for Arc<BoundColumnFamily<'_>> {
     fn inner(&self) -> *mut ffi::rocksdb_column_family_handle_t {
         self.inner
     }
@@ -191,5 +191,5 @@ unsafe impl Send for ColumnFamily {}
 unsafe impl Sync for ColumnFamily {}
 unsafe impl Send for UnboundColumnFamily {}
 unsafe impl Sync for UnboundColumnFamily {}
-unsafe impl<'a> Send for BoundColumnFamily<'a> {}
-unsafe impl<'a> Sync for BoundColumnFamily<'a> {}
+unsafe impl Send for BoundColumnFamily<'_> {}
+unsafe impl Sync for BoundColumnFamily<'_> {}

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -377,7 +377,7 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
     }
 }
 
-impl<'a, D: DBAccess> Drop for DBRawIteratorWithThreadMode<'a, D> {
+impl<D: DBAccess> Drop for DBRawIteratorWithThreadMode<'_, D> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_iter_destroy(self.inner.as_ptr());
@@ -385,8 +385,8 @@ impl<'a, D: DBAccess> Drop for DBRawIteratorWithThreadMode<'a, D> {
     }
 }
 
-unsafe impl<'a, D: DBAccess> Send for DBRawIteratorWithThreadMode<'a, D> {}
-unsafe impl<'a, D: DBAccess> Sync for DBRawIteratorWithThreadMode<'a, D> {}
+unsafe impl<D: DBAccess> Send for DBRawIteratorWithThreadMode<'_, D> {}
+unsafe impl<D: DBAccess> Sync for DBRawIteratorWithThreadMode<'_, D> {}
 
 /// A type alias to keep compatibility. See [`DBIteratorWithThreadMode`] for details
 pub type DBIterator<'a> = DBIteratorWithThreadMode<'a, DB>;
@@ -501,7 +501,7 @@ impl<'a, D: DBAccess> DBIteratorWithThreadMode<'a, D> {
     }
 }
 
-impl<'a, D: DBAccess> Iterator for DBIteratorWithThreadMode<'a, D> {
+impl<D: DBAccess> Iterator for DBIteratorWithThreadMode<'_, D> {
     type Item = Result<KVBytes, Error>;
 
     fn next(&mut self) -> Option<Result<KVBytes, Error>> {
@@ -521,7 +521,7 @@ impl<'a, D: DBAccess> Iterator for DBIteratorWithThreadMode<'a, D> {
     }
 }
 
-impl<'a, D: DBAccess> std::iter::FusedIterator for DBIteratorWithThreadMode<'a, D> {}
+impl<D: DBAccess> std::iter::FusedIterator for DBIteratorWithThreadMode<'_, D> {}
 
 impl<'a, D: DBAccess> Into<DBRawIteratorWithThreadMode<'a, D>> for DBIteratorWithThreadMode<'a, D> {
     fn into(self) -> DBRawIteratorWithThreadMode<'a, D> {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1461,9 +1461,10 @@ impl Options {
     /// UniversalCompactionBuilder::PickPeriodicCompaction().
     /// For backward compatibility, the effective value of this option takes
     /// into account the value of option `ttl`. The logic is as follows:
-    ///    - both options are set to 30 days if they have the default value.
-    ///    - if both options are zero, zero is picked. Otherwise, we take the min
-    ///    value among non-zero options values (i.e. takes the stricter limit).
+    ///
+    /// - both options are set to 30 days if they have the default value.
+    /// - if both options are zero, zero is picked. Otherwise, we take the min
+    ///   value among non-zero options values (i.e. takes the stricter limit).
     ///
     /// One main use of the feature is to make sure a file goes through compaction
     /// filters periodically. Users can also use the feature to clear up SST
@@ -1991,8 +1992,8 @@ impl Options {
     /// The exact behavior of this parameter is platform dependent.
     ///
     /// On POSIX systems, after RocksDB reads data from disk it will
-    /// mark the pages as "unneeded". The operating system may - or may not
-    /// - evict these pages from memory, reducing pressure on the system
+    /// mark the pages as "unneeded". The operating system may or may not
+    /// evict these pages from memory, reducing pressure on the system
     /// cache. If the disk block is requested again this can result in
     /// additional disk I/O.
     ///
@@ -3465,9 +3466,11 @@ impl Options {
     /// to be able to ingest behind (call IngestExternalFile() skipping keys
     /// that already exist, rather than overwriting matching keys).
     /// Setting this option to true has the following effects:
-    /// 1) Disable some internal optimizations around SST file compression.
-    /// 2) Reserve the last level for ingested files only.
-    /// 3) Compaction will not include any file from the last level.
+    ///
+    /// 1. Disable some internal optimizations around SST file compression.
+    /// 2. Reserve the last level for ingested files only.
+    /// 3. Compaction will not include any file from the last level.
+    ///
     /// Note that only Universal Compaction supports allow_ingest_behind.
     /// `num_levels` should be >= 3 if this option is turned on.
     ///
@@ -3568,10 +3571,12 @@ impl Options {
     /// or an IDENTITY file (historical, deprecated), or both. If this option is
     /// set to false (old behavior), then `write_identity_file` must be set to true.
     /// The manifest is preferred because
+    ///
     /// 1. The IDENTITY file is not checksummed, so it is not as safe against
     ///    corruption.
     /// 2. The IDENTITY file may or may not be copied with the DB (e.g. not
     ///    copied by BackupEngine), so is not reliable for the provenance of a DB.
+    ///
     /// This option might eventually be obsolete and removed as Identity files
     /// are phased out.
     ///

--- a/src/db_pinnable_slice.rs
+++ b/src/db_pinnable_slice.rs
@@ -28,17 +28,17 @@ pub struct DBPinnableSlice<'a> {
     db: PhantomData<&'a DB>,
 }
 
-unsafe impl<'a> Send for DBPinnableSlice<'a> {}
-unsafe impl<'a> Sync for DBPinnableSlice<'a> {}
+unsafe impl Send for DBPinnableSlice<'_> {}
+unsafe impl Sync for DBPinnableSlice<'_> {}
 
-impl<'a> AsRef<[u8]> for DBPinnableSlice<'a> {
+impl AsRef<[u8]> for DBPinnableSlice<'_> {
     fn as_ref(&self) -> &[u8] {
         // Implement this via Deref so as not to repeat ourselves
         self
     }
 }
 
-impl<'a> Deref for DBPinnableSlice<'a> {
+impl Deref for DBPinnableSlice<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &[u8] {
@@ -50,7 +50,7 @@ impl<'a> Deref for DBPinnableSlice<'a> {
     }
 }
 
-impl<'a> Drop for DBPinnableSlice<'a> {
+impl Drop for DBPinnableSlice<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_pinnableslice_destroy(self.ptr);
@@ -58,7 +58,7 @@ impl<'a> Drop for DBPinnableSlice<'a> {
     }
 }
 
-impl<'a> DBPinnableSlice<'a> {
+impl DBPinnableSlice<'_> {
     /// Used to wrap a PinnableSlice from rocksdb to avoid unnecessary memcpy
     ///
     /// # Unsafe

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -259,7 +259,7 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
     }
 }
 
-impl<'a, D: DBAccess> Drop for SnapshotWithThreadMode<'a, D> {
+impl<D: DBAccess> Drop for SnapshotWithThreadMode<'_, D> {
     fn drop(&mut self) {
         unsafe {
             self.db.release_snapshot(self.inner);
@@ -269,5 +269,5 @@ impl<'a, D: DBAccess> Drop for SnapshotWithThreadMode<'a, D> {
 
 /// `Send` and `Sync` implementations for `SnapshotWithThreadMode` are safe, because `SnapshotWithThreadMode` is
 /// immutable and can be safely shared between threads.
-unsafe impl<'a, D: DBAccess> Send for SnapshotWithThreadMode<'a, D> {}
-unsafe impl<'a, D: DBAccess> Sync for SnapshotWithThreadMode<'a, D> {}
+unsafe impl<D: DBAccess> Send for SnapshotWithThreadMode<'_, D> {}
+unsafe impl<D: DBAccess> Sync for SnapshotWithThreadMode<'_, D> {}

--- a/src/sst_file_writer.rs
+++ b/src/sst_file_writer.rs
@@ -27,8 +27,8 @@ pub struct SstFileWriter<'a> {
     phantom: PhantomData<&'a Options>,
 }
 
-unsafe impl<'a> Send for SstFileWriter<'a> {}
-unsafe impl<'a> Sync for SstFileWriter<'a> {}
+unsafe impl Send for SstFileWriter<'_> {}
+unsafe impl Sync for SstFileWriter<'_> {}
 
 struct EnvOptions {
     inner: *mut ffi::rocksdb_envoptions_t,
@@ -205,7 +205,7 @@ impl<'a> SstFileWriter<'a> {
     }
 }
 
-impl<'a> Drop for SstFileWriter<'a> {
+impl Drop for SstFileWriter<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_sstfilewriter_destroy(self.inner);

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -33,9 +33,9 @@ pub struct Transaction<'db, DB> {
     pub(crate) _marker: PhantomData<&'db DB>,
 }
 
-unsafe impl<'db, DB> Send for Transaction<'db, DB> {}
+unsafe impl<DB> Send for Transaction<'_, DB> {}
 
-impl<'db, DB> DBAccess for Transaction<'db, DB> {
+impl<DB> DBAccess for Transaction<'_, DB> {
     unsafe fn create_snapshot(&self) -> *const ffi::rocksdb_snapshot_t {
         ffi::rocksdb_transaction_get_snapshot(self.inner)
     }
@@ -116,7 +116,7 @@ impl<'db, DB> DBAccess for Transaction<'db, DB> {
     }
 }
 
-impl<'db, DB> Transaction<'db, DB> {
+impl<DB> Transaction<'_, DB> {
     /// Write all batched keys to the DB atomically.
     ///
     /// May return any error that could be returned by `DB::write`.
@@ -892,7 +892,7 @@ impl<'db, DB> Transaction<'db, DB> {
     }
 }
 
-impl<'db, DB> Drop for Transaction<'db, DB> {
+impl<DB> Drop for Transaction<'_, DB> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_transaction_destroy(self.inner);


### PR DESCRIPTION
* One unnescessary borrow
* Some named lifetimes that can be elided
* Wanted/unwanted lists in doc comments
* A test with `mem::transmute` to extend lifetimes where clippy recommends type annotations (rewritten to use scoped threads instead)