### PR TITLE
Fix error_message argument type

### DIFF
--- a/librocksdb-sys/src/test.rs
+++ b/librocksdb-sys/src/test.rs
@@ -20,7 +20,7 @@ use std::str;
 
 use super::*;
 
-pub fn error_message(ptr: *const i8) -> String {
+pub fn error_message(ptr: *const c_char) -> String {
     let c_str = unsafe { CStr::from_ptr(ptr as *const _) };
     let s = str::from_utf8(c_str.to_bytes()).unwrap().to_owned();
     unsafe {


### PR DESCRIPTION
Hello.

Some of the tests that were re-enabled in v0.17 of librocksdb-sys fail to compile on at least arm64, armel and riscv64 on Debian infrastructure due to a bad argument type (`error[E0308]: mismatched types`, `expected *const i8, found *mut u8`):

- https://ci.debian.net/packages/r/rust-librocksdb-sys/testing/arm64/56531952/
- https://ci.debian.net/packages/r/rust-librocksdb-sys/testing/armel/56531584/
- https://ci.debian.net/packages/r/rust-librocksdb-sys/testing/riscv64/56538194/

This PR uses libc's `c_char` instead of `i8` as the argument of `error_message` so as to match the corresponding variable in `internal`.

Cheers!