### PR TITLE
Add function to set sync flag in backup engine options

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -273,6 +273,12 @@ impl BackupEngineOptions {
             ffi::rocksdb_backup_engine_options_set_sync(self.inner, c_uchar::from(sync));
         }
     }
+
+    /// Returns the value of the `sync` option.
+    pub fn get_sync(&mut self) -> bool {
+        let val_u8 = unsafe { ffi::rocksdb_backup_engine_options_get_sync(self.inner) };
+        val_u8 != 0
+    }
 }
 
 impl RestoreOptions {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -265,7 +265,7 @@ impl BackupEngineOptions {
     /// it to false will speed things up a bit, but some (newer) backups might be inconsistent. In
     /// most cases, everything should be fine, though.
     ///
-    /// Default: false
+    /// Default: true
     ///
     /// Documentation: <https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB#advanced-usage>
     pub fn set_sync(&mut self, sync: bool) {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -259,6 +259,20 @@ impl BackupEngineOptions {
             );
         }
     }
+
+    /// Sets whether to use fsync(2) to sync file data and metadata to disk after every file write,
+    /// guaranteeing that backups will be consistent after a reboot or if machine crashes. Setting
+    /// it to false will speed things up a bit, but some (newer) backups might be inconsistent. In
+    /// most cases, everything should be fine, though.
+    ///
+    /// Default: false
+    ///
+    /// Documentation: <https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB#advanced-usage>
+    pub fn set_sync(&mut self, sync: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_sync(self.inner, c_uchar::from(sync));
+        }
+    }
 }
 
 impl RestoreOptions {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -329,3 +329,21 @@ impl Drop for RestoreOptions {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BackupEngineOptions;
+
+    #[test]
+    fn test_sync() {
+        let dir = tempfile::Builder::new()
+            .prefix("rocksdb-test-sync")
+            .tempdir()
+            .expect("Failed to create temporary path for db.");
+
+        let mut opts = BackupEngineOptions::new(dir.path()).unwrap();
+        assert!(opts.get_sync());
+        opts.set_sync(false);
+        assert!(!opts.get_sync());
+    }
+}

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1783,6 +1783,12 @@ impl Options {
         }
     }
 
+    /// Returns the value of the `use_fsync` option.
+    pub fn get_use_fsync(&self) -> bool {
+        let val = unsafe { ffi::rocksdb_options_get_use_fsync(self.inner) };
+        val != 0
+    }
+
     /// Specifies the absolute info LOG dir.
     ///
     /// If it is empty, the log files will be in the same dir as data.

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -4680,6 +4680,14 @@ mod tests {
     }
 
     #[test]
+    fn test_use_fsync() {
+        let mut opts = Options::default();
+        assert!(!opts.get_use_fsync());
+        opts.set_use_fsync(true);
+        assert!(opts.get_use_fsync());
+    }
+
+    #[test]
     fn test_set_stats_persist_period_sec() {
         let mut opts = Options::default();
         opts.enable_statistics();


### PR DESCRIPTION
I'd like to set this sync flag in [Qdrant](https://github.com/qdrant/qdrant). Enabling this well invoke `fsync(2)` when recovering a RocksDB backup, helping with durability.

It's roughly described here: https://github.com/facebook/rocksdb/wiki/How-to-backup-RocksDB#advanced-usage