### PR TITLE
Define correct name for jemalloc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config libjemalloc-dev
       - name: Set PKG_CONFIG_PATH
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
       - name: Run clippy
@@ -124,6 +124,9 @@ jobs:
       - name: Install dependencies
         if: runner.os == 'Windows'
         run: choco install llvm -y
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libjemalloc-dev
       - name: Mark working directory as read-only
         if: runner.os == 'Linux'
         run: |

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -243,7 +243,8 @@ fn build_rocksdb() {
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
 
     if cfg!(feature = "jemalloc") {
-        config.define("WITH_JEMALLOC", "ON");
+        config.define("ROCKSDB_JEMALLOC", Some("1"));
+        config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
     }
 
     #[cfg(feature = "io-uring")]

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -243,8 +243,11 @@ fn build_rocksdb() {
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
 
     if cfg!(feature = "jemalloc") {
-        config.define("ROCKSDB_JEMALLOC", Some("1"));
-        config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+        // Only enable jemalloc in linux.
+        if target.contains("linux") {
+            config.define("ROCKSDB_JEMALLOC", Some("1"));
+            config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+        }
     }
 
     #[cfg(feature = "io-uring")]

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,6 +1,11 @@
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process::Command};
 
+ // On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
+ // with RocksDB.
+ // See https://github.com/tikv/jemallocator/blob/tikv-jemalloc-sys-0.5.3/jemalloc-sys/src/env.rs#L25
+ const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
+
 fn link(name: &str, bundled: bool) {
     use std::env::var;
     let target = var("TARGET").unwrap();
@@ -241,14 +246,14 @@ fn build_rocksdb() {
     }
 
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
-
-    if cfg!(feature = "jemalloc") {
-        // Only enable jemalloc in linux.
-        if target.contains("linux") {
-            config.define("ROCKSDB_JEMALLOC", Some("1"));
-            config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
-        }
-    }
+    
+    if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
+         config.define("ROCKSDB_JEMALLOC", Some("1"));
+         config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+         if let Some(jemalloc_root) = env::var_os("DEP_JEMALLOC_ROOT") {
+             config.include(Path::new(&jemalloc_root).join("include"));
+         }
+     }
 
     #[cfg(feature = "io-uring")]
     if target.contains("linux") {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process::Command};
 
- // On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
- // with RocksDB.
- // See https://github.com/tikv/jemallocator/blob/tikv-jemalloc-sys-0.5.3/jemalloc-sys/src/env.rs#L25
- const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
+// On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
+// with RocksDB.
+// See https://github.com/tikv/jemallocator/blob/tikv-jemalloc-sys-0.5.3/jemalloc-sys/src/env.rs#L25
+const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
 
 fn link(name: &str, bundled: bool) {
     use std::env::var;
@@ -246,14 +246,14 @@ fn build_rocksdb() {
     }
 
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
-    
+
     if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
-         config.define("ROCKSDB_JEMALLOC", Some("1"));
-         config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
-         if let Some(jemalloc_root) = env::var_os("DEP_JEMALLOC_ROOT") {
-             config.include(Path::new(&jemalloc_root).join("include"));
-         }
-     }
+        config.define("ROCKSDB_JEMALLOC", Some("1"));
+        config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+        if let Some(jemalloc_root) = env::var_os("DEP_JEMALLOC_ROOT") {
+            config.include(Path::new(&jemalloc_root).join("include"));
+        }
+    }
 
     #[cfg(feature = "io-uring")]
     if target.contains("linux") {


### PR DESCRIPTION
`WITH_JEMALLOC` is not recognized by rocksdb.
`ROCKSDB_JEMALLOC` is the correct one.