### PR TITLE
Fix bindgen-static build

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -37,7 +37,10 @@ tikv-jemalloc-sys = { version = "0.6", features = [
     "unprefixed_malloc_on_supported_platforms",
 ], optional = true }
 lz4-sys = { version = "1.10", optional = true }
-zstd-sys = { version = "2.0", features = ["zdict_builder"], optional = true }
+zstd-sys = { version = "2.0", default-features = false, features = [
+    "legacy",
+    "zdict_builder",
+], optional = true }
 libz-sys = { version = "1.1", default-features = false, optional = true }
 bzip2-sys = { version = "0.1", default-features = false, optional = true }
 


### PR DESCRIPTION
## Problem

`zstd-sys`'s default feature `bindgen` enables bindgen `runtime` feature, resulting in compile failure when using `bindgen-static`:

```
`runtime` and `static` features can't be combined
```

## Fix

disable the `bindgen` feature of [`zstd-sys`](https://github.com/gyscos/zstd-rs/blob/main/zstd-safe/zstd-sys/Cargo.toml) which is enabled by default:

zstd-sys/Cargo.toml
```
[features]
default = ["legacy", "zdict_builder", "bindgen"]
```

This won't affect anything as the binding is pre-generated
```
This library includes a pre-generated bindings.rs file. You can also generate new bindings at build-time, using the bindgen feature:

cargo build --features bindgen
```