### PR TITLE
db_options.rs: deprecate set_ignore_range_deletions (RocksDB 10.2.1)

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3979,10 +3979,12 @@ impl ReadOptions {
     }
 
     /// If true, keys deleted using the DeleteRange() API will be visible to
-    /// readers until they are naturally deleted during compaction. This improves
-    /// read performance in DBs with many range deletions.
+    /// readers until they are naturally deleted during compaction.
     ///
     /// Default: false
+    #[deprecated(
+        note = "deprecated in RocksDB 10.2.1: no performance impact if DeleteRange is not used"
+    )]
     pub fn set_ignore_range_deletions(&mut self, v: bool) {
         unsafe {
             ffi::rocksdb_readoptions_set_ignore_range_deletions(self.inner, c_uchar::from(v));


### PR DESCRIPTION
RocksDB 10.2.1 is marking this API as deprecated. The upstream documentation has changed to state the following. Update rustdoc to match, and mark with #[deprecated]. Currently rust-rocksdb is not using this version of RocksDB, but presumably it will eventually, so we might as well mark this as deprecated now.

Upstream RocksDB comment:

```
// DEPRECATED: This option might be removed in a future release.
// There should be no noticeable performance difference whether this option
// is turned on or off when a DB does not use DeleteRange().
```

https://github.com/facebook/rocksdb/blob/v10.2.1/include/rocksdb/options.h#L1837