### PR TITLE
Implement WriteBatchIteratorCf trait and update related methods for compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,9 @@ pub use crate::{
         OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, TransactionDB,
         TransactionDBOptions, TransactionOptions,
     },
-    write_batch::{WriteBatch, WriteBatchIterator, WriteBatchWithTransaction},
+    write_batch::{
+        WriteBatch, WriteBatchIterator, WriteBatchIteratorCf, WriteBatchWithTransaction,
+    },
 };
 
 use librocksdb_sys as ffi;

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -105,7 +105,7 @@ unsafe extern "C" fn writebatch_put_cf_callback<T: WriteBatchIteratorCf>(
     let callbacks = &mut *(state as *mut T);
     let key = slice::from_raw_parts(k as *const u8, klen);
     let value = slice::from_raw_parts(v as *const u8, vlen);
-    callbacks.put_cf(cfid, key, value)
+    callbacks.put_cf(cfid, key, value);
 }
 
 unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
@@ -116,7 +116,7 @@ unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     let callbacks = &mut *(state as *mut T);
     let key = slice::from_raw_parts(k as *const u8, klen);
-    callbacks.delete_cf(cfid, key)
+    callbacks.delete_cf(cfid, key);
 }
 
 unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
@@ -130,7 +130,7 @@ unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
     let callbacks = &mut *(state as *mut T);
     let key = slice::from_raw_parts(k as *const u8, klen);
     let value = slice::from_raw_parts(v as *const u8, vlen);
-    callbacks.merge_cf(cfid, key, value)
+    callbacks.merge_cf(cfid, key, value);
 }
 
 impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
@@ -202,7 +202,7 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 state,
                 Some(writebatch_put_callback::<T>),
                 Some(writebatch_delete_callback::<T>),
-            )
+            );
         }
     }
 
@@ -215,7 +215,7 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 Some(writebatch_put_cf_callback::<T>),
                 Some(writebatch_delete_cf_callback::<T>),
                 Some(writebatch_merge_cf_callback::<T>),
-            )
+            );
         }
     }
 

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -454,10 +454,10 @@ struct OperationCounts {
 }
 
 impl rocksdb::WriteBatchIterator for OperationCounts {
-    fn put(&mut self, _key: Box<[u8]>, _value: Box<[u8]>) {
+    fn put(&mut self, _key: &[u8], _value: &[u8]) {
         self.puts += 1;
     }
-    fn delete(&mut self, _key: Box<[u8]>) {
+    fn delete(&mut self, _key: &[u8]) {
         self.deletes += 1;
     }
 }

--- a/tests/test_write_batch.rs
+++ b/tests/test_write_batch.rs
@@ -40,7 +40,7 @@ fn test_write_batch_with_serialized_data() {
         fn put(&mut self, key: &[u8], value: &[u8]) {
             match self.data.remove(key.as_ref()) {
                 Some(expect) => {
-                    assert_eq!(value.as_ref(), expect.as_slice());
+                    assert_eq!(value, expect.as_slice());
                 }
                 None => {
                     panic!("key not exists");
@@ -80,7 +80,7 @@ fn test_write_batch_cf_with_serialized_data() {
             match self.data.remove(key.as_ref()) {
                 Some((expect_cf_id, expect)) => {
                     assert_eq!(cf_id, expect_cf_id);
-                    assert_eq!(value.as_ref(), expect.as_slice());
+                    assert_eq!(value, expect.as_slice());
                 }
                 None => {
                     panic!("key not exists");


### PR DESCRIPTION
By the way, when using the WriteBatchIterator, remove the dynamic trait (dyn) and switch to static dispatch.