### PR TITLE
ffi_util.rs: improve opt_bytes_to_str to fix (#693)

### DIFF
--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -43,7 +43,12 @@ pub fn error_message(ptr: *const c_char) -> String {
     }
 }
 
-pub fn opt_bytes_to_ptr<T: AsRef<[u8]>>(opt: Option<T>) -> *const c_char {
+/// Returns a raw pointer to borrowed bytes, or null if None.
+///
+/// # Safety
+/// - The input must outlive the returned pointer.
+/// - Common types: `&str`, `&[u8]`, `&String`, `&Vec<u8>`
+pub fn opt_bytes_to_ptr<T: AsRef<[u8]> + ?Sized>(opt: Option<&T>) -> *const c_char {
     match opt {
         Some(v) => v.as_ref().as_ptr() as *const c_char,
         None => ptr::null(),


### PR DESCRIPTION
# Unsound API design in opt_bytes_to_ptr

The original `opt_bytes_to_ptr` function accepts a parameter of type `Option<T> where T: AsRef<[u8]>`. While this is flexible, it also allows owned types like `String` or `Vec<u8>` to be passed in. Since the function takes ownership of T, any owned data (like a `String`) will be dropped at the end of the function scope.

This results in undefined behavior, as the returned `*const c_char` pointer may point to memory that is already freed, leading to dangling pointers.

See the example below:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=a59bc55798c258040f5aa04c9e60c1b5

## Fix: Change to borrowed data
To resolve this, the function should accept a borrowed reference instead, such as:
The function no longer takes ownership of the data.
The returned pointer is guaranteed to be valid for at least as long as the input reference.

## Safety Note
It is the caller's responsibility to ensure the borrowed data outlives any use of the returned raw pointer. This is a standard requirement when interfacing with raw C-style APIs.

## Additional Changes
Added documentation to clarify the ownership and lifetime requirements of the input data and returned pointer.