### PR TITLE
Update broken bindgen issue link to new repository location

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -35,7 +35,7 @@ fn bindgen_rocksdb() {
     let bindings = bindgen::Builder::default()
         .header(rocksdb_include_dir() + "/rocksdb/c.h")
         .derive_debug(false)
-        .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
+        .blocklist_type("max_align_t") // https://github.com/rust-lang/rust-bindgen/issues/550
         .ctypes_prefix("libc")
         .size_t_is_usize(true)
         .generate()


### PR DESCRIPTION
The original comment referenced an outdated GitHub issue link for rust-bindgen regarding the max_align_t blocklist workaround.
This commit updates the URL to point to the current location of the issue in the rust-lang/rust-bindgen repository:
https://github.com/rust-lang/rust-bindgen/issues/550
This helps future maintainers understand the reason for blocking max_align_t and provides a working reference for more context.