### PR TITLE
Untie PinnableSlices' lifetime from their transaction's lifetime

### DIFF
--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -227,7 +227,10 @@ impl<'db, DB> Transaction<'db, DB> {
         self.get_opt(key, &ReadOptions::default())
     }
 
-    pub fn get_pinned<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<DBPinnableSlice<'db>>, Error> {
+    pub fn get_pinned<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+    ) -> Result<Option<DBPinnableSlice<'db>>, Error> {
         self.get_pinned_opt(key, &ReadOptions::default())
     }
 


### PR DESCRIPTION
Hey! Here is a small PR that should solve a problem of mine.

Fixes #1005

Disclaimer: I'm not 100% sure this is correct. And actually, considering the implementation of DBPinnableSlice, I'd suggest even removing the lifetime parameter altogether — lifetime seems to be reference-counted, so why are we even keeping the `&'db DB` as a phantomdata in the transaction itself?

Anyway, thank you for all your work on the rust rocksdb bindings!