### PR TITLE
Run cargo clippy --fix with Rust 1.88

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -388,9 +388,9 @@ fn update_submodules() {
 
     match ret.map(|status| (status.success(), status.code())) {
         Ok((true, _)) => (),
-        Ok((false, Some(c))) => panic!("Command failed with error code {}", c),
+        Ok((false, Some(c))) => panic!("Command failed with error code {c}"),
         Ok((false, None)) => panic!("Command got killed"),
-        Err(e) => panic!("Command failed with error: {}", e),
+        Err(e) => panic!("Command failed with error: {e}"),
     }
 }
 
@@ -410,7 +410,7 @@ fn main() {
                 Some(_) => "static",
                 None => "dylib",
             };
-            println!("cargo:rustc-link-lib={}=rocksdb", mode);
+            println!("cargo:rustc-link-lib={mode}=rocksdb");
 
             return;
         }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2732,7 +2732,7 @@ impl Options {
             MemtableFactory::HashLinkList { bucket_count } => unsafe {
                 ffi::rocksdb_options_set_hash_link_list_rep(self.inner, bucket_count);
             },
-        };
+        }
     }
 
     pub fn set_block_based_table_factory(&mut self, factory: &BlockBasedOptions) {

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -61,7 +61,7 @@ fn test_column_family() {
         match db.create_cf("cf1", &opts) {
             Ok(()) => println!("cf1 created successfully"),
             Err(e) => {
-                panic!("could not create column family: {}", e);
+                panic!("could not create column family: {e}");
             }
         }
     }
@@ -86,7 +86,7 @@ fn test_column_family() {
         opts.set_merge_operator_associative("test operator", test_provided_merge);
         match DB::open_cf(&opts, &n, ["cf1"]) {
             Ok(_db) => println!("successfully opened db with column family"),
-            Err(e) => panic!("failed to open db with column family: {}", e),
+            Err(e) => panic!("failed to open db with column family: {e}"),
         }
     }
 
@@ -96,7 +96,7 @@ fn test_column_family() {
         let vec = DB::list_cf(&opts, &n);
         match vec {
             Ok(vec) => assert_eq!(vec, vec![DEFAULT_COLUMN_FAMILY_NAME, "cf1"]),
-            Err(e) => panic!("failed to drop column family: {}", e),
+            Err(e) => panic!("failed to drop column family: {e}"),
         }
     }
 
@@ -113,7 +113,7 @@ fn test_column_family() {
 
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
-            Err(e) => panic!("failed to drop column family: {}", e),
+            Err(e) => panic!("failed to drop column family: {e}"),
         }
     }
 }
@@ -135,7 +135,7 @@ fn test_column_family_with_transactiondb() {
         match db.create_cf("cf1", &opts) {
             Ok(()) => println!("cf1 created successfully"),
             Err(e) => {
-                panic!("could not create column family: {}", e);
+                panic!("could not create column family: {e}");
             }
         }
     }
@@ -179,7 +179,7 @@ fn test_column_family_with_transactiondb() {
         );
         match db {
             Ok(_db) => println!("successfully opened db with column family"),
-            Err(e) => panic!("failed to open db with column family: {}", e),
+            Err(e) => panic!("failed to open db with column family: {e}"),
         }
     }
 
@@ -189,7 +189,7 @@ fn test_column_family_with_transactiondb() {
         let vec = DB::list_cf(&opts, &n);
         match vec {
             Ok(vec) => assert_eq!(vec, vec![DEFAULT_COLUMN_FAMILY_NAME, "cf1"]),
-            Err(e) => panic!("failed to drop column family: {}", e),
+            Err(e) => panic!("failed to drop column family: {e}"),
         }
     }
 
@@ -215,7 +215,7 @@ fn test_column_family_with_transactiondb() {
         .unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
-            Err(e) => panic!("failed to drop column family: {}", e),
+            Err(e) => panic!("failed to drop column family: {e}"),
         }
     }
     // should not be able to open cf after dropping.
@@ -279,7 +279,7 @@ fn test_create_missing_column_family() {
 
         match DB::open_cf(&opts, &n, ["cf1"]) {
             Ok(_db) => println!("successfully created new column family"),
-            Err(e) => panic!("failed to create new column family: {}", e),
+            Err(e) => panic!("failed to create new column family: {e}"),
         }
     }
 }
@@ -304,7 +304,7 @@ fn test_open_column_family_with_opts() {
         let cfs = vec![("cf1", cf1_opts), ("cf2", cf2_opts)];
         match DB::open_cf_with_opts(&opts, &n, cfs) {
             Ok(_db) => println!("successfully opened column family with the specified options"),
-            Err(e) => panic!("failed to open cf with options: {}", e),
+            Err(e) => panic!("failed to open cf with options: {e}"),
         }
     }
 }
@@ -322,7 +322,7 @@ fn test_merge_operator() {
                 println!("successfully opened db with column family");
                 db
             }
-            Err(e) => panic!("failed to open db with column family: {}", e),
+            Err(e) => panic!("failed to open db with column family: {e}"),
         };
         let cf1 = db.cf_handle("cf1").unwrap();
         assert!(db.put_cf(&cf1, b"k1", b"v1").is_ok());
@@ -389,8 +389,7 @@ fn test_column_family_with_options() {
             Ok(_db) => println!("created db with column family descriptors successfully"),
             Err(e) => {
                 panic!(
-                    "could not create new database with column family descriptors: {}",
-                    e
+                    "could not create new database with column family descriptors: {e}"
                 );
             }
         }
@@ -408,8 +407,7 @@ fn test_column_family_with_options() {
             Ok(_db) => println!("successfully re-opened database with column family descriptors"),
             Err(e) => {
                 panic!(
-                    "unable to re-open database with column family descriptors: {}",
-                    e
+                    "unable to re-open database with column family descriptors: {e}"
                 );
             }
         }

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -388,9 +388,7 @@ fn test_column_family_with_options() {
         match DB::open_cf_descriptors(&opts, &n, cfs) {
             Ok(_db) => println!("created db with column family descriptors successfully"),
             Err(e) => {
-                panic!(
-                    "could not create new database with column family descriptors: {e}"
-                );
+                panic!("could not create new database with column family descriptors: {e}");
             }
         }
     }
@@ -406,9 +404,7 @@ fn test_column_family_with_options() {
         match DB::open_cf_descriptors(&opts, &n, cfs) {
             Ok(_db) => println!("successfully re-opened database with column family descriptors"),
             Err(e) => {
-                panic!(
-                    "unable to re-open database with column family descriptors: {e}"
-                );
+                panic!("unable to re-open database with column family descriptors: {e}");
             }
         }
     }

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -54,9 +54,7 @@ fn test_comparator() {
     let local_compare = move |one: &[u8], two: &[u8]| one.cmp(two);
     let x = 0;
     let local_compare_reverse = move |one: &[u8], two: &[u8]| {
-        println!(
-            "Use the x value from the closure scope to do something smart: {x:?}"
-        );
+        println!("Use the x value from the closure scope to do something smart: {x:?}");
         match one.cmp(two) {
             Ordering::Less => Ordering::Greater,
             Ordering::Equal => Ordering::Equal,
@@ -71,9 +69,7 @@ fn test_comparator() {
     println!("Keys in normal sort order, closure: {res_closure:?}");
     assert_eq!(res_closure, old_res);
     let res_closure_reverse = write_to_db_with_comparator(Box::new(local_compare_reverse));
-    println!(
-        "Keys in reverse sort order, closure: {res_closure_reverse:?}"
-    );
+    println!("Keys in reverse sort order, closure: {res_closure_reverse:?}");
     assert_eq!(vec!["b-key", "a-key"], res_closure_reverse);
 }
 

--- a/tests/test_comparator.rs
+++ b/tests/test_comparator.rs
@@ -55,8 +55,7 @@ fn test_comparator() {
     let x = 0;
     let local_compare_reverse = move |one: &[u8], two: &[u8]| {
         println!(
-            "Use the x value from the closure scope to do something smart: {:?}",
-            x
+            "Use the x value from the closure scope to do something smart: {x:?}"
         );
         match one.cmp(two) {
             Ordering::Less => Ordering::Greater,
@@ -66,15 +65,14 @@ fn test_comparator() {
     };
 
     let old_res = write_to_db_with_comparator(Box::new(rocks_old_compare));
-    println!("Keys in normal sort order, no closure: {:?}", old_res);
+    println!("Keys in normal sort order, no closure: {old_res:?}");
     assert_eq!(vec!["a-key", "b-key"], old_res);
     let res_closure = write_to_db_with_comparator(Box::new(local_compare));
-    println!("Keys in normal sort order, closure: {:?}", res_closure);
+    println!("Keys in normal sort order, closure: {res_closure:?}");
     assert_eq!(res_closure, old_res);
     let res_closure_reverse = write_to_db_with_comparator(Box::new(local_compare_reverse));
     println!(
-        "Keys in reverse sort order, closure: {:?}",
-        res_closure_reverse
+        "Keys in reverse sort order, closure: {res_closure_reverse:?}"
     );
     assert_eq!(vec!["b-key", "a-key"], res_closure_reverse);
 }

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -1699,8 +1699,8 @@ fn test_get_approximate_sizes_cf() {
 
         // Insert some data
         for i in 0..1000 {
-            let key = format!("key_{:04}", i);
-            let value = format!("value_{:04}", i);
+            let key = format!("key_{i:04}");
+            let value = format!("value_{i:04}");
             db.put_cf(&cf, key.as_bytes(), value.as_bytes()).unwrap();
         }
 

--- a/tests/test_merge_operator.rs
+++ b/tests/test_merge_operator.rs
@@ -229,7 +229,7 @@ fn counting_merge_test() {
         Ok(Some(value)) => ValueCounts::from_slice(&value)
             .map_or_else(|| panic!("unable to create ValueCounts from bytes"), |v| v),
         Ok(None) => panic!("value not present"),
-        Err(e) => panic!("error reading value {:?}", e),
+        Err(e) => panic!("error reading value {e:?}"),
     };
 
     let counts = value_getter(b"k2");
@@ -265,13 +265,12 @@ fn failed_merge_test() {
     db.put(b"key", b"value").expect("put_ok");
     let res = db.merge(b"key", b"new value");
     match res.and_then(|_e| db.get(b"key")) {
-        Ok(val) => panic!("expected merge failure to propagate, got: {:?}", val),
+        Ok(val) => panic!("expected merge failure to propagate, got: {val:?}"),
         Err(e) => {
             let msg = e.into_string();
             assert!(
                 msg.contains("Merge operator failed"),
-                "unexpected merge error message: {}",
-                msg
+                "unexpected merge error message: {msg}"
             );
         }
     }

--- a/tests/test_optimistic_transaction_db_memory_usage.rs
+++ b/tests/test_optimistic_transaction_db_memory_usage.rs
@@ -40,16 +40,16 @@ fn test_optimistic_transaction_db_memory_usage() {
         let memory_usage = builder.build().unwrap();
 
         for i in 1..=1000 {
-            let key = format!("key{}", i);
-            let value = format!("value{}", i);
+            let key = format!("key{i}");
+            let value = format!("value{i}");
             db.put(&key, &value).unwrap();
         }
 
         for i in 1..=1000 {
-            let key = format!("key{}", i);
+            let key = format!("key{i}");
             let result = db.get(&key).unwrap().unwrap();
             let result_str = String::from_utf8(result).unwrap();
-            assert_eq!(result_str, format!("value{}", i));
+            assert_eq!(result_str, format!("value{i}"));
         }
 
         assert_ne!(memory_usage.approximate_mem_table_total(), 0);

--- a/tests/test_transaction_db_memory_usage.rs
+++ b/tests/test_transaction_db_memory_usage.rs
@@ -48,13 +48,13 @@ fn test_transaction_db_memory_usage() {
         let memory_usage = builder.build().unwrap();
 
         for i in 1..=1000 {
-            let key = format!("key{}", i);
-            let value = format!("value{}", i);
+            let key = format!("key{i}");
+            let value = format!("value{i}");
             db.put(&key, &value).unwrap();
         }
 
         for i in 1..=1000 {
-            let key = format!("key{}", i);
+            let key = format!("key{i}");
             let result = db.get(&key).unwrap().unwrap();
             let result_str = String::from_utf8(result).unwrap();
             assert_eq!(result_str, format!("value{}", i));


### PR DESCRIPTION
This fixes clippy warnings when using the newest stable release of Rust. These are backwards-compatible, so seem worth fixing now. Most of the warnings are formatting strings, such as the following:
```
warning: variables can be used directly in the `format!` string
   --> librocksdb-sys/build.rs:393:19
    |
393 |         Err(e) => panic!("Command failed with error: {}", e),
```
There was one unnecessary semicolon on `src/db_options.rs:2735`.

There is one clippy warning remaining with Rust 1.88: Using Debug for a Path (`src/db.rs:2645`). I left this unchanged.