### PR TITLE
Options.set_skip_checking_sst_file_sizes_on_db_open: deprecated

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -2630,6 +2630,7 @@ impl Options {
     /// not checked at all.
     ///
     /// Default: false
+    #[deprecated(note = "RocksDB >= 10.5: option is ignored: checking done with a thread pool")]
     pub fn set_skip_checking_sst_file_sizes_on_db_open(&mut self, value: bool) {
         unsafe {
             ffi::rocksdb_options_set_skip_checking_sst_file_sizes_on_db_open(


### PR DESCRIPTION
RocksDB 10.5.0 has marked this option as deprecated. It will do nothing. The rust-rocksdb crate is still using RocksDB 9.10.0, so this deprecation notice is a bit premature. However, I assume we will eventually upgrade, and this notice will then be correct.