### PR TITLE
unsafe changes from cargo --fix with Rust 2024

### DIFF
--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -100,14 +100,14 @@ pub unsafe extern "C" fn destructor_callback<F>(raw_cb: *mut c_void)
 where
     F: CompactionFilter,
 {
-    drop(Box::from_raw(raw_cb as *mut F));
+    drop(unsafe { Box::from_raw(raw_cb as *mut F) });
 }
 
 pub unsafe extern "C" fn name_callback<F>(raw_cb: *mut c_void) -> *const c_char
 where
     F: CompactionFilter,
 {
-    let cb = &*(raw_cb as *mut F);
+    let cb = unsafe { &*(raw_cb as *mut F) };
     cb.name().as_ptr()
 }
 
@@ -127,17 +127,17 @@ where
 {
     use self::Decision::{Change, Keep, Remove};
 
-    let cb = &mut *(raw_cb as *mut F);
-    let key = slice::from_raw_parts(raw_key as *const u8, key_length);
-    let oldval = slice::from_raw_parts(existing_value as *const u8, value_length);
+    let cb = unsafe { &mut *(raw_cb as *mut F) };
+    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_length) };
+    let oldval = unsafe { slice::from_raw_parts(existing_value as *const u8, value_length) };
     let result = cb.filter(level as u32, key, oldval);
     match result {
         Keep => 0,
         Remove => 1,
         Change(newval) => {
-            *new_value = newval.as_ptr() as *mut c_char;
-            *new_value_length = newval.len() as size_t;
-            *value_changed = 1_u8;
+            unsafe { *new_value = newval.as_ptr() as *mut c_char };
+            unsafe { *new_value_length = newval.len() as size_t };
+            unsafe { *value_changed = 1_u8 };
             0
         }
     }

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -31,11 +31,11 @@ pub struct ComparatorCallback {
 
 impl ComparatorCallback {
     pub unsafe extern "C" fn destructor_callback(raw_cb: *mut c_void) {
-        drop(Box::from_raw(raw_cb as *mut Self));
+        drop(unsafe { Box::from_raw(raw_cb as *mut Self) });
     }
 
     pub unsafe extern "C" fn name_callback(raw_cb: *mut c_void) -> *const c_char {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
         let ptr = cb.name.as_ptr();
         ptr as *const c_char
     }
@@ -47,9 +47,9 @@ impl ComparatorCallback {
         b_raw: *const c_char,
         b_len: size_t,
     ) -> c_int {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
-        let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
-        let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
         (cb.compare_fn)(a, b) as c_int
     }
 }
@@ -63,11 +63,11 @@ pub struct ComparatorWithTsCallback {
 
 impl ComparatorWithTsCallback {
     pub unsafe extern "C" fn destructor_callback(raw_cb: *mut c_void) {
-        drop(Box::from_raw(raw_cb as *mut Self));
+        drop(unsafe { Box::from_raw(raw_cb as *mut Self) });
     }
 
     pub unsafe extern "C" fn name_callback(raw_cb: *mut c_void) -> *const c_char {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
         let ptr = cb.name.as_ptr();
         ptr as *const c_char
     }
@@ -79,9 +79,9 @@ impl ComparatorWithTsCallback {
         b_raw: *const c_char,
         b_len: size_t,
     ) -> c_int {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
-        let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
-        let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
         (cb.compare_fn)(a, b) as c_int
     }
 
@@ -92,9 +92,9 @@ impl ComparatorWithTsCallback {
         b_ts_raw: *const c_char,
         b_ts_len: size_t,
     ) -> c_int {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
-        let a_ts: &[u8] = slice::from_raw_parts(a_ts_raw as *const u8, a_ts_len);
-        let b_ts: &[u8] = slice::from_raw_parts(b_ts_raw as *const u8, b_ts_len);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
+        let a_ts: &[u8] = unsafe { slice::from_raw_parts(a_ts_raw as *const u8, a_ts_len) };
+        let b_ts: &[u8] = unsafe { slice::from_raw_parts(b_ts_raw as *const u8, b_ts_len) };
         (cb.compare_ts_fn)(a_ts, b_ts) as c_int
     }
 
@@ -107,10 +107,10 @@ impl ComparatorWithTsCallback {
         b_len: size_t,
         b_has_ts_raw: c_uchar,
     ) -> c_int {
-        let cb: &mut Self = &mut *(raw_cb as *mut Self);
-        let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
+        let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
         let a_has_ts = a_has_ts_raw != 0;
-        let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
         let b_has_ts = b_has_ts_raw != 0;
         (cb.compare_without_ts_fn)(a, a_has_ts, b, b_has_ts) as c_int
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -211,15 +211,15 @@ pub trait DBAccess {
 
 impl<T: ThreadMode, D: DBInner> DBAccess for DBCommon<T, D> {
     unsafe fn create_snapshot(&self) -> *const ffi::rocksdb_snapshot_t {
-        ffi::rocksdb_create_snapshot(self.inner.inner())
+        unsafe { ffi::rocksdb_create_snapshot(self.inner.inner()) }
     }
 
     unsafe fn release_snapshot(&self, snapshot: *const ffi::rocksdb_snapshot_t) {
-        ffi::rocksdb_release_snapshot(self.inner.inner(), snapshot);
+        unsafe { ffi::rocksdb_release_snapshot(self.inner.inner(), snapshot) };
     }
 
     unsafe fn create_iterator(&self, readopts: &ReadOptions) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_create_iterator(self.inner.inner(), readopts.inner)
+        unsafe { ffi::rocksdb_create_iterator(self.inner.inner(), readopts.inner) }
     }
 
     unsafe fn create_iterator_cf(
@@ -227,7 +227,7 @@ impl<T: ThreadMode, D: DBInner> DBAccess for DBCommon<T, D> {
         cf_handle: *mut ffi::rocksdb_column_family_handle_t,
         readopts: &ReadOptions,
     ) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_create_iterator_cf(self.inner.inner(), readopts.inner, cf_handle)
+        unsafe { ffi::rocksdb_create_iterator_cf(self.inner.inner(), readopts.inner, cf_handle) }
     }
 
     fn get_opt<K: AsRef<[u8]>>(

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use std::ptr;
 
 pub(crate) unsafe fn from_cstr(ptr: *const c_char) -> String {
-    let cstr = CStr::from_ptr(ptr as *const _);
+    let cstr = unsafe { CStr::from_ptr(ptr as *const _) };
     String::from_utf8_lossy(cstr.to_bytes()).into_owned()
 }
 
@@ -29,7 +29,7 @@ pub(crate) unsafe fn raw_data(ptr: *const c_char, size: usize) -> Option<Vec<u8>
         None
     } else {
         let mut dst = vec![0; size];
-        ptr::copy_nonoverlapping(ptr as *const u8, dst.as_mut_ptr(), size);
+        unsafe { ptr::copy_nonoverlapping(ptr as *const u8, dst.as_mut_ptr(), size) };
 
         Some(dst)
     }

--- a/src/prop_name.rs
+++ b/src/prop_name.rs
@@ -160,7 +160,7 @@ impl PropertyName {
     #[inline]
     unsafe fn from_vec_with_nul_unchecked(inner: Vec<u8>) -> Self {
         // SAFETY: Caller promises inner is nul-terminated and valid UTF-8.
-        Self(CString::from_vec_with_nul_unchecked(inner))
+        Self(unsafe { CString::from_vec_with_nul_unchecked(inner) })
     }
 
     /// Converts the value into a C string.
@@ -296,7 +296,7 @@ pub(crate) unsafe fn level_property(name: &str, level: usize) -> PropertyName {
     let bytes = format!("rocksdb.{name}{level}\0").into_bytes();
     // SAFETY: We’re appending terminating nul and caller promises `name` has no
     // interior nul bytes.
-    PropertyName::from_vec_with_nul_unchecked(bytes)
+    unsafe { PropertyName::from_vec_with_nul_unchecked(bytes) }
 }
 
 #[test]

--- a/src/slice_transform.rs
+++ b/src/slice_transform.rs
@@ -83,11 +83,11 @@ pub struct TransformCallback<'a> {
 }
 
 pub unsafe extern "C" fn slice_transform_destructor_callback(raw_cb: *mut c_void) {
-    drop(Box::from_raw(raw_cb as *mut TransformCallback));
+    drop(unsafe { Box::from_raw(raw_cb as *mut TransformCallback) });
 }
 
 pub unsafe extern "C" fn slice_transform_name_callback(raw_cb: *mut c_void) -> *const c_char {
-    let cb = &mut *(raw_cb as *mut TransformCallback);
+    let cb = unsafe { &mut *(raw_cb as *mut TransformCallback) };
     cb.name.as_ptr()
 }
 
@@ -97,10 +97,10 @@ pub unsafe extern "C" fn transform_callback(
     key_len: size_t,
     dst_length: *mut size_t,
 ) -> *mut c_char {
-    let cb = &mut *(raw_cb as *mut TransformCallback);
-    let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+    let cb = unsafe { &mut *(raw_cb as *mut TransformCallback) };
+    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
     let prefix = (cb.transform_fn)(key);
-    *dst_length = prefix.len() as size_t;
+    unsafe { *dst_length = prefix.len() as size_t };
     prefix.as_ptr() as *mut c_char
 }
 
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn in_domain_callback(
     raw_key: *const c_char,
     key_len: size_t,
 ) -> c_uchar {
-    let cb = &mut *(raw_cb as *mut TransformCallback);
-    let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+    let cb = unsafe { &mut *(raw_cb as *mut TransformCallback) };
+    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
     c_uchar::from(cb.in_domain_fn.map_or(true, |in_domain| in_domain(key)))
 }

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -93,10 +93,12 @@ unsafe extern "C" fn writebatch_put_callback<T: WriteBatchIterator>(
     v: *const c_char,
     vlen: usize,
 ) {
-    let callbacks = &mut *(state as *mut T);
-    let key = slice::from_raw_parts(k as *const u8, klen);
-    let value = slice::from_raw_parts(v as *const u8, vlen);
-    callbacks.put(key, value);
+    unsafe {
+        let callbacks = &mut *(state as *mut T);
+        let key = slice::from_raw_parts(k as *const u8, klen);
+        let value = slice::from_raw_parts(v as *const u8, vlen);
+        callbacks.put(key, value);
+    }
 }
 
 unsafe extern "C" fn writebatch_delete_callback<T: WriteBatchIterator>(
@@ -104,9 +106,11 @@ unsafe extern "C" fn writebatch_delete_callback<T: WriteBatchIterator>(
     k: *const c_char,
     klen: usize,
 ) {
-    let callbacks = &mut *(state as *mut T);
-    let key = slice::from_raw_parts(k as *const u8, klen);
-    callbacks.delete(key);
+    unsafe {
+        let callbacks = &mut *(state as *mut T);
+        let key = slice::from_raw_parts(k as *const u8, klen);
+        callbacks.delete(key);
+    }
 }
 
 unsafe extern "C" fn writebatch_put_cf_callback<T: WriteBatchIteratorCf>(
@@ -117,10 +121,12 @@ unsafe extern "C" fn writebatch_put_cf_callback<T: WriteBatchIteratorCf>(
     v: *const c_char,
     vlen: usize,
 ) {
-    let callbacks = &mut *(state as *mut T);
-    let key = slice::from_raw_parts(k as *const u8, klen);
-    let value = slice::from_raw_parts(v as *const u8, vlen);
-    callbacks.put_cf(cfid, key, value);
+    unsafe {
+        let callbacks = &mut *(state as *mut T);
+        let key = slice::from_raw_parts(k as *const u8, klen);
+        let value = slice::from_raw_parts(v as *const u8, vlen);
+        callbacks.put_cf(cfid, key, value);
+    }
 }
 
 unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
@@ -129,9 +135,11 @@ unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
     k: *const c_char,
     klen: usize,
 ) {
-    let callbacks = &mut *(state as *mut T);
-    let key = slice::from_raw_parts(k as *const u8, klen);
-    callbacks.delete_cf(cfid, key);
+    unsafe {
+        let callbacks = &mut *(state as *mut T);
+        let key = slice::from_raw_parts(k as *const u8, klen);
+        callbacks.delete_cf(cfid, key);
+    }
 }
 
 unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
@@ -142,10 +150,12 @@ unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
     v: *const c_char,
     vlen: usize,
 ) {
-    let callbacks = &mut *(state as *mut T);
-    let key = slice::from_raw_parts(k as *const u8, klen);
-    let value = slice::from_raw_parts(v as *const u8, vlen);
-    callbacks.merge_cf(cfid, key, value);
+    unsafe {
+        let callbacks = &mut *(state as *mut T);
+        let key = slice::from_raw_parts(k as *const u8, klen);
+        let value = slice::from_raw_parts(v as *const u8, vlen);
+        callbacks.merge_cf(cfid, key, value);
+    }
 }
 
 impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {


### PR DESCRIPTION
Rust 2024 now warns when performing unsafe operations inside unsafe functions. This change adds unsafe blocks from cargo --fix, to make it easier to eventually upgrade this crate to Rust 2024.

See:
https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html