### PR TITLE
Remove set_skip_prepare method from TransactionOptions

### DIFF
--- a/src/transactions/options.rs
+++ b/src/transactions/options.rs
@@ -38,12 +38,6 @@ impl TransactionOptions {
         TransactionOptions::default()
     }
 
-    pub fn set_skip_prepare(&mut self, skip_prepare: bool) {
-        unsafe {
-            ffi::rocksdb_transaction_options_set_set_snapshot(self.inner, u8::from(skip_prepare));
-        }
-    }
-
     /// Specifies use snapshot or not.
     ///
     /// Default: false.


### PR DESCRIPTION
The set_skip_prepare method has been removed from TransactionOptions because there is no corresponding function in the RocksDB C API or in the project's FFI layer to support this option. The previous implementation incorrectly called the set_snapshot FFI function, which is unrelated to skip_prepare. Keeping this method would mislead users into thinking this option is supported, while in reality it has no effect. This change ensures the Rust API accurately reflects the available functionality in the underlying RocksDB library.