### PR TITLE
Ensure jemalloc is linked in when the feature is enabled

### DIFF
--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -26,6 +26,8 @@ extern crate bzip2_sys;
 extern crate libz_sys;
 #[cfg(feature = "lz4")]
 extern crate lz4_sys;
+#[cfg(feature = "jemalloc")]
+extern crate tikv_jemalloc_sys;
 #[cfg(feature = "zstd")]
 extern crate zstd_sys;
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -472,7 +472,16 @@ fn jemalloc_init() {
         .read_to_string(&mut log_content)
         .expect("can read the LOG file");
 
-    if cfg!(feature = "jemalloc") {
+    if cfg!(feature = "jemalloc")
+        && !(
+            // See NO_JEMALLOC_TARGETS in librocksdb-sys/build.rs
+            cfg!(target_os = "android")
+                || cfg!(target_os = "dragonfly")
+                || cfg!(target_env = "musl")
+                || cfg!(target_os = "macos")
+                || cfg!(target_os = "ios")
+        )
+    {
         assert!(log_content.contains("Jemalloc supported: 1"));
     } else {
         assert!(log_content.contains("Jemalloc supported: 0"));


### PR DESCRIPTION
On Unix systems, RocksDB itself only declares weak references to jemalloc symbols ([example](https://github.com/facebook/rocksdb/blob/13f054febb26100184eeefaac11877d735d45ac2/port/jemalloc_helper.h#L60-L61)) – even if `ROCKSDB_JEMALLOC` is defined properly. As such, unless the program has a separate strong reference to jemalloc, the linker will decide that linking jemalloc is unnecessary.

Force the linker to treat jemalloc as necessary by adding a `extern crate` declaration, similar to existing system crates.

Tested via https://github.com/timothyg-stripe/rust-rocksdb-1026:

> Before:
>
> ```
> $ nm target/debug/server | grep mallocx
>                  w mallocx
> $ target/debug/server && grep Jemalloc /tmp/rocksdb-test/LOG
> Opened the db
> 2025/08/09-17:12:32.621073 2437467 Jemalloc supported: 0
> ```
>
> After:
>
> ```
> $ nm target/debug/server | grep mallocx
> 0000000000919eef T mallocx
> $ target/debug/server && grep Jemalloc /tmp/rocksdb-test/LOG
> Opened the db
> 2025/08/09-17:19:27.774256 2464427 Jemalloc supported: 1
> ```

Also added a unit test:

* Before this PR: ❌ https://github.com/timothyg-stripe/rust-rocksdb/actions/runs/16852387139/job/47740558546#step:14:229
* After: ✅ https://github.com/timothyg-stripe/rust-rocksdb/actions/runs/16852385315/job/47740554486#step:14:231

Fixes #863