### PR TITLE
fix: use correct FFI setter for skip_prepare in RocksDB transaction options

### DIFF
--- a/src/transactions/options.rs
+++ b/src/transactions/options.rs
@@ -40,7 +40,7 @@ impl TransactionOptions {
 
     pub fn set_skip_prepare(&mut self, skip_prepare: bool) {
         unsafe {
-            ffi::rocksdb_transaction_options_set_set_snapshot(self.inner, u8::from(skip_prepare));
+            ffi::rocksdb_transaction_options_set_skip_prepare(self.inner, u8::from(skip_prepare));
         }
     }
 


### PR DESCRIPTION
- Replaced incorrect logic with the proper FFI call `rocksdb_transaction_options_set_skip_prepare`.
- Ensures `skip_prepare` option is correctly applied when configuring RocksDB transactions.