### PR TITLE
fix: correct ASCII comment to UTF-8 for consistency

### DIFF
--- a/src/prop_name.rs
+++ b/src/prop_name.rs
@@ -48,7 +48,7 @@ impl PropName {
     /// returned slice.
     #[inline]
     pub fn as_str(&self) -> &str {
-        // SAFETY: self.0 is guaranteed to be valid ASCII string.
+        // SAFETY: self.0 is guaranteed to be valid UTF-8 string.
         unsafe { std::str::from_utf8_unchecked(self.0.to_bytes()) }
     }
 }


### PR DESCRIPTION
- Fix comment on line 51 in as_str() method to say "UTF-8 string" instead of "ASCII string"