### PR TITLE
Build with -mpclmul when avx is available

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -143,7 +143,9 @@ fn build_rocksdb() {
         if target_features.contains(&"lzcnt") {
             config.flag_if_supported("-mlzcnt");
         }
-        if !target.contains("android") && target_features.contains(&"pclmulqdq") {
+        if !target.contains("android")
+            && (target_features.contains(&"pclmulqdq") || target_features.contains(&"avx"))
+        {
             config.flag_if_supported("-mpclmul");
         }
     }


### PR DESCRIPTION
The code fails to build with `RUSTFLAGS='-C target-cpu=x86-64-v3'` on Linux. The error message indicates that `-mpclmul` is missing:

```
  cargo:warning=In file included from rocksdb/util/crc32c.cc:52:                                      
  cargo:warning=rocksdb/util/crc32c.cc: In function 'uint64_t rocksdb::crc32c::CombineCRC(size_t, uint64_t, uint64_t, uint64_t, const uint64_t*)':                                                           
  cargo:warning=rocksdb/util/crc32c.cc:553:21: error: '__builtin_ia32_pclmulqdq128' needs isa option -mpclmul -msse2                                                                                         
  cargo:warning=  553 |   const auto res0 = _mm_clmulepi64_si128(crc0_xmm, multiplier, 0x00);         
  cargo:warning=      |                     ^~~~~~~~~~~~~~~~~~~~                                      
  cargo:warning=rocksdb/util/crc32c.cc:555:21: error: '__builtin_ia32_pclmulqdq128' needs isa option -mpclmul -msse2                                                                                         
  cargo:warning=  555 |   const auto res1 = _mm_clmulepi64_si128(crc1_xmm, multiplier, 0x10);         
  cargo:warning=      |                     ^~~~~~~~~~~~~~~~~~~~
```

It looks like RocksDB defines `__PCLMUL__` as long as `__AVX__` is detected:

https://github.com/facebook/rocksdb/blob/631fb8670b077aa80c3953ceb3ed5c82649db515/port/lang.h#L78-L83

So we have to do the same: add `-mpclmul` if `avx` is detected.