### PR TITLE
fix: compaction filter non-static Change

### DIFF
--- a/tests/test_compactionfilter.rs
+++ b/tests/test_compactionfilter.rs
@@ -22,10 +22,10 @@ use util::DBPath;
 #[cfg(test)]
 #[allow(unused_variables)]
 fn test_filter(level: u32, key: &[u8], value: &[u8]) -> CompactionDecision {
-    use self::CompactionDecision::*;
+    use crate::CompactionDecision::*;
     match key.first() {
         Some(&b'_') => Remove,
-        Some(&b'%') => Change(b"secret"),
+        Some(&b'%') => Change(b"secret".to_vec()),
         _ => Keep,
     }
 }


### PR DESCRIPTION
Presently the compaction filter declare the Change case of the Decision enum as
holding 'static [u8] slice. That made it rather useless in safe Rust as any
non-trivial data change must leak the returned data.

To address that replace the static slice in the Change data with Vec<u8>. The
change callback implementation then stores this vector in the thread-local data
and return a pointer to it. This is safe as on C++ side RocksDB uses the
returned pointer just to copy the data pointed to it to C++ string immediately
after the callback call.

Then the code use various opportuneties to drop the the thread-local storage
like the following callback calls or the vallback destruction.

This is a breaking change as it changes the type of publically facing
Decision::Change payload. However upgrading the existing code should be trivial.
And in case the code does not use the Change no changes will be necessary.

EDIT: the initial PR code that was using lifetime bounds is replaced with the current PR based on thread-local Vec workaround. Hopefully RocksDB C-compatible public API at some point will either provide a way to define the change data destructor or to populate C++ string from inside the callback. 