### PR TITLE
DBOptions.get_options_from_string: Fix leak on error

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -14,12 +14,10 @@
 //
 
 use crate::{
-    column_family::AsColumnFamilyRef,
-    column_family::BoundColumnFamily,
-    column_family::UnboundColumnFamily,
+    column_family::{AsColumnFamilyRef, BoundColumnFamily, UnboundColumnFamily},
     db_options::OptionsMustOutliveDB,
     ffi,
-    ffi_util::{from_cstr, opt_bytes_to_ptr, raw_data, to_cpath, CStrLike},
+    ffi_util::{convert_rocksdb_error, from_cstr, opt_bytes_to_ptr, raw_data, to_cpath, CStrLike},
     ColumnFamily, ColumnFamilyDescriptor, CompactOptions, DBIteratorWithThreadMode,
     DBPinnableSlice, DBRawIteratorWithThreadMode, DBWALIterator, Direction, Error, FlushOptions,
     IngestExternalFileOptions, IteratorMode, Options, ReadOptions, SnapshotWithThreadMode,
@@ -1319,7 +1317,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                             Ok(Some(DBPinnableSlice::from_c(v)))
                         }
                     } else {
-                        Err(Error::new(crate::ffi_util::error_message(e)))
+                        Err(convert_rocksdb_error(e))
                     }
                 })
                 .collect()
@@ -2741,7 +2739,7 @@ pub(crate) fn convert_values(
                 }
                 Ok(value)
             } else {
-                Err(Error::new(crate::ffi_util::error_message(e)))
+                Err(convert_rocksdb_error(e))
             }
         })
         .collect()

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -63,6 +63,16 @@ fn test_get_options_from_string() {
     assert!(opts
         .get_options_from_string("notarealoptionstring")
         .is_err());
+
+    // test an option with a NUL byte
+    let err = match opts.get_options_from_string("use_fsync=false\0") {
+        Ok(_) => panic!("expected error"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("must not contain NUL"),
+        "err={err:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
If the rocksdb_get_options_from_string failed, we had 2 leaks:

* We forgot to free the newly allocated new_options value created by rocksdb_options_create. To avoid this: immediately wrap the result in an Options struct, so it will get dropped on all code paths.
* We forgot to free the errptr RocksDB error message. Use ffi_try! to fix this, which is what we do everywhere else.

Additionally: into_c_string() will fail if the Rust string contains NUL (0x00) bytes. Convert the .expect() into a result and add a test for this case.

To make error conversions a bit clearer, rename error_message to convert_rocksdb_error. Add a doc comment that it will free the argument. Also change the function to return an Error, since it is always used in that way. Also add a doc comment to ffi_try!.