### PR TITLE
MemoryUsageBuilder: Prevent outliving the DBs/caches

### DIFF
--- a/tests/fail/memory_usage_builder_outlive_db.rs
+++ b/tests/fail/memory_usage_builder_outlive_db.rs
@@ -1,0 +1,10 @@
+use rocksdb::{perf::MemoryUsageBuilder, DB};
+
+fn main() {
+    let mut builder = MemoryUsageBuilder::new().unwrap();
+    {
+        let db = DB::open_default("foo").unwrap();
+        builder.add_db(&db);
+    }
+    let _memory_usage = builder.build().unwrap();
+}

--- a/tests/fail/memory_usage_builder_outlive_db.stderr
+++ b/tests/fail/memory_usage_builder_outlive_db.stderr
@@ -1,0 +1,11 @@
+error[E0597]: `db` does not live long enough
+ --> tests/fail/memory_usage_builder_outlive_db.rs:7:24
+  |
+6 |         let db = DB::open_default("foo").unwrap();
+  |             -- binding `db` declared here
+7 |         builder.add_db(&db);
+  |                        ^^^ borrowed value does not live long enough
+8 |     }
+  |     - `db` dropped here while still borrowed
+9 |     let _memory_usage = builder.build().unwrap();
+  |                         ------- borrow later used here

--- a/tests/test_perf.rs
+++ b/tests/test_perf.rs
@@ -1,0 +1,25 @@
+use rocksdb::{
+    perf::{get_memory_usage_stats, MemoryUsageBuilder},
+    DB,
+};
+
+#[test]
+fn test_memory_usage_builder() {
+    let tempdir = tempfile::tempdir().unwrap();
+
+    let db = DB::open_default(tempdir.path()).unwrap();
+    let mut builder = MemoryUsageBuilder::new().unwrap();
+    builder.add_db(&db);
+    let memory_usage = builder.build().unwrap();
+    assert!(memory_usage.approximate_mem_table_total() > 0);
+
+    // alternative non-builder approach
+    let memory_usage = get_memory_usage_stats(Some(&[&db]), None).unwrap();
+    assert!(memory_usage.mem_table_total > 0);
+}
+
+#[test]
+fn test_memory_usage_builder_outlive_db() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/fail/memory_usage_builder_outlive_db.rs");
+}


### PR DESCRIPTION
This type must not outlive the DBs and caches that are added to it, otherwise the caller will access invalid memory and likely crash. Use PhantomData to ensure it does not outlive its arguments. This is technically a breaking API change, but anything that used this code in this way was likely broken anyway.