### PR TITLE
DBCommon.get_column_family_metadata(_cf): Fix memory leak

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -17,7 +17,10 @@ use crate::{
     column_family::{AsColumnFamilyRef, BoundColumnFamily, UnboundColumnFamily},
     db_options::OptionsMustOutliveDB,
     ffi,
-    ffi_util::{convert_rocksdb_error, from_cstr, opt_bytes_to_ptr, raw_data, to_cpath, CStrLike},
+    ffi_util::{
+        convert_rocksdb_error, from_cstr_and_free, from_cstr_without_free, opt_bytes_to_ptr,
+        raw_data, to_cpath, CStrLike,
+    },
     ColumnFamily, ColumnFamilyDescriptor, CompactOptions, DBIteratorWithThreadMode,
     DBPinnableSlice, DBRawIteratorWithThreadMode, DBWALIterator, Direction, Error, FlushOptions,
     IngestExternalFileOptions, IteratorMode, Options, ReadOptions, SnapshotWithThreadMode,
@@ -924,7 +927,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
             let vec = slice::from_raw_parts(ptr, length)
                 .iter()
-                .map(|ptr| CStr::from_ptr(*ptr).to_string_lossy().into_owned())
+                .map(|ptr| from_cstr_without_free(*ptr))
                 .collect();
             ffi::rocksdb_list_column_families_destroy(ptr, length);
             Ok(vec)
@@ -2391,7 +2394,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
             let metadata = ColumnFamilyMetaData {
                 size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr(ffi::rocksdb_column_family_metadata_get_name(ptr)),
+                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
                 file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
             };
 
@@ -2413,7 +2416,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
             let metadata = ColumnFamilyMetaData {
                 size: ffi::rocksdb_column_family_metadata_get_size(ptr),
-                name: from_cstr(ffi::rocksdb_column_family_metadata_get_name(ptr)),
+                name: from_cstr_and_free(ffi::rocksdb_column_family_metadata_get_name(ptr)),
                 file_count: ffi::rocksdb_column_family_metadata_get_file_count(ptr),
             };
 
@@ -2439,9 +2442,10 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 let mut key_size: usize = 0;
 
                 for i in 0..n {
+                    // rocksdb_livefiles_* returns pointers to strings, not copies
                     let column_family_name =
-                        from_cstr(ffi::rocksdb_livefiles_column_family_name(files, i));
-                    let name = from_cstr(ffi::rocksdb_livefiles_name(files, i));
+                        from_cstr_without_free(ffi::rocksdb_livefiles_column_family_name(files, i));
+                    let name = from_cstr_without_free(ffi::rocksdb_livefiles_name(files, i));
                     let size = ffi::rocksdb_livefiles_size(files, i);
                     let level = ffi::rocksdb_livefiles_level(files, i);
 

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use libc::{c_int, c_uchar, c_void};
+use libc::{c_int, c_uchar};
 
-use crate::{db::DBInner, ffi, ffi_util::from_cstr, Cache, Error};
+use crate::ffi_util::from_cstr_and_free;
+use crate::{db::DBInner, ffi, Cache, Error};
 use crate::{DBCommon, ThreadMode, TransactionDB, DB};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -155,9 +156,7 @@ impl PerfContext {
         unsafe {
             let ptr =
                 ffi::rocksdb_perfcontext_report(self.inner, c_uchar::from(exclude_zero_counters));
-            let report = from_cstr(ptr);
-            ffi::rocksdb_free(ptr as *mut c_void);
-            report
+            from_cstr_and_free(ptr)
         }
     }
 


### PR DESCRIPTION
This function previously called
rocksdb_column_family_metadata_get_name, which returns a malloc-ed C string, without freeing it. Fix this, and try to make this kind of mistake less likely by renaming the helper functions. This way, the caller needs to think about if the string must be freed or not. Most of the existing uses are actually from_cstr_and_free.

* Rename from_cstr to from_cstr_without_free
* Add from_cstr_and_free, which always frees the C string.
* Change existing uses to call the correct variant.