### PR TITLE
Options.set_info_logger: Reference count to fix memory leak

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3817,7 +3817,7 @@ impl Options {
     /// directory; this can be changed to a custom callback with the
     /// [`InfoLogger::new_callback_logger`] constructor.
     pub fn set_info_logger(&mut self, mut logger: InfoLogger) {
-        // Clone the callback so it can be shared across database instances
+        // Move the callback so it can be shared across database instances
         self.outlive.logger_callback = logger.callback.take();
         unsafe {
             ffi::rocksdb_options_set_info_log(self.inner, logger.inner);


### PR DESCRIPTION
The Boxed callback was previously leaked due to this line:

    let cb = Box::into_raw(Box::new(cb));

This was never freed. To free it, put the boxed callback in an Arc and put it in OptionsMustOutliveDB. This did require changing logger_callback to use dyn Fn, instead of being a generic function. This avoids needing the generic type on OptionsMustOutliveDB. It may have some additional overhead, but it should not matter since the log function isn't called that often.

Extend the unit test to check that the reference counting works.

Found by running valgrind on all the tests.