### PR TITLE
librocksdb-sys/build.rs: sync defines with RocksDB

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -156,8 +156,8 @@ fn build_rocksdb() {
     // true for C++ >= 17; we set -std=c++20 below
     config.define("HAVE_ALIGNED_NEW", None);
 
-    // __uint128_t is only supported by GCC and Clang (I think)
-    // TODO: implement a detection script since we could be using clang on Windows
+    // __uint128_t is supported by GCC and Clang; Don't use it for MSVC
+    // TODO: implement a detection script?
     if !target.contains("msvc") {
         config.define("HAVE_UINT128_EXTENSION", None);
     }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -106,6 +106,15 @@ fn build_rocksdb() {
     config.include(".");
     config.define("NDEBUG", Some("1"));
 
+    // true for C++ >= 17; we set -std=c++20 below
+    config.define("HAVE_ALIGNED_NEW", None);
+
+    // __uint128_t is only supported by GCC and Clang (I think)
+    // TODO: implement a detection script since we could be using clang on Windows
+    if !target.contains("msvc") {
+        config.define("HAVE_UINT128_EXTENSION", None);
+    }
+
     let mut lib_sources = include_str!("rocksdb_lib_sources.txt")
         .trim()
         .split('\n')
@@ -180,6 +189,9 @@ fn build_rocksdb() {
         config.define("ROCKSDB_PLATFORM_POSIX", None);
         config.define("ROCKSDB_LIB_IO_POSIX", None);
         config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
+        config.define("ROCKSDB_AUXV_GETAUXVAL_PRESENT", None);
+        config.define("ROCKSDB_FALLOCATE_PRESENT", None);
+        config.define("ROCKSDB_RANGESYNC_PRESENT", None);
     } else if target.contains("dragonfly") {
         config.define("OS_DRAGONFLYBSD", None);
         config.define("ROCKSDB_PLATFORM_POSIX", None);
@@ -244,8 +256,6 @@ fn build_rocksdb() {
         }
     }
 
-    config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
-
     if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
         config.define("ROCKSDB_JEMALLOC", Some("1"));
         config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
@@ -273,6 +283,7 @@ fn build_rocksdb() {
             config.static_crt(true);
         }
         config.flag("-EHsc");
+        // Don't use cxx_standard: Uses : instead of =
         config.flag("-std:c++20");
     } else {
         config.flag(cxx_standard());
@@ -298,7 +309,6 @@ fn build_rocksdb() {
     config.file("build_version.cc");
 
     config.cpp(true);
-    config.flag_if_supported("-std=c++20");
 
     if !target.contains("windows") {
         config.flag("-include").flag("cstdint");
@@ -366,6 +376,8 @@ fn try_to_find_and_link_lib(lib_name: &str) -> bool {
     false
 }
 
+/// Returns the value of the `ROCKSDB_CXX_STD` env var, or the default `-std=c++{version}` flag for
+/// building RocksDB.
 fn cxx_standard() -> String {
     env::var("ROCKSDB_CXX_STD").map_or("-std=c++20".to_owned(), |cxx_std| {
         if !cxx_std.starts_with("-std=") {


### PR DESCRIPTION
This adds 4 RocksDB defines which are enabled by default when using make in the upstream project. It removes ROCKSDB_SUPPORT_THREAD_LOCAL which was removed from RocksDB in commit 0a43061f8d29 on 2022-05-18, which was included in RocksDB v7.3.1.

Remove an extra config.flag_if_supported("-std=c++20"): The C++ standard is set by the cxx_standard() above.

Defines that were added:

* HAVE_ALIGNED_NEW: This is true for C++ >= 17. RocksDB requires this standard in new versions, so I think this should be safe. It also only controls padding in the StatisticsImpl class in RocksDB, so it probably does not matter much.

* HAVE_UINT128_EXTENSION: Used to control if __uint128_t exists. Both GCC and Clang support it, but MSVC++ does not. Define it when building with anything other than MSVC.

* ROCKSDB_FALLOCATE_PRESENT: The fallocate function and option constants have been defined for Linux for many years. This is used for the WAL and manifest.

* ROCKSDB_RANGESYNC_PRESENT: sync_file_range is used by the bytes_per_sync option. It has existed on Linux for more than 15 years.

Defines I did not add:

* ROCKSDB_PTHREAD_ADAPTIVE_MUTEX apparently not supported by musl and seems to default to off. Unless users explicitly turn this on, it won't do anything. Probably does not matter much.

* ROCKSDB_BACKTRACE: Prints C++ stack traces on certain error conditions. Probably not that useful for Rust projects.