### PR TITLE
feat: add flush and flush_wal API wrappers for TransactionDB

### DIFF
--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -37,10 +37,10 @@ use crate::{
     DBIteratorWithThreadMode, DBPinnableSlice, DBRawIteratorWithThreadMode, Direction, Error,
     IteratorMode, MultiThreaded, Options, ReadOptions, SingleThreaded, SnapshotWithThreadMode,
     ThreadMode, Transaction, TransactionDBOptions, TransactionOptions, WriteBatchWithTransaction,
-    WriteOptions, DB, DEFAULT_COLUMN_FAMILY_NAME,
+    FlushOptions, WriteOptions, DB, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use ffi::rocksdb_transaction_t;
-use libc::{c_char, c_int, c_void, size_t};
+use libc::{c_char, c_int, c_uchar, c_void, size_t};
 
 #[cfg(not(feature = "multi-threaded-cf"))]
 type DefaultThreadMode = crate::SingleThreaded;
@@ -395,6 +395,34 @@ impl<T: ThreadMode> TransactionDB<T> {
 
     pub fn path(&self) -> &Path {
         self.path.as_path()
+    }
+
+    /// Flushes the WAL buffer. If `sync` is set to `true`, also syncs
+    /// the data to disk.
+    pub fn flush_wal(&self, sync: bool) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_transactiondb_flush_wal(
+                self.inner,
+                c_uchar::from(sync)
+            ));
+        }
+        Ok(())
+    }
+
+    /// Flushes database memtables to SST files on the disk.
+    pub fn flush_opt(&self, flushopts: &FlushOptions) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_transactiondb_flush(
+                self.inner,
+                flushopts.inner
+            ));
+        }
+        Ok(())
+    }
+
+    /// Flushes database memtables to SST files on the disk using default options.
+    pub fn flush(&self) -> Result<(), Error> {
+        self.flush_opt(&FlushOptions::default())
     }
 
     /// Creates a transaction with default options.

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -35,9 +35,9 @@ use crate::{
     ffi_util::to_cpath,
     AsColumnFamilyRef, BoundColumnFamily, ColumnFamily, ColumnFamilyDescriptor,
     DBIteratorWithThreadMode, DBPinnableSlice, DBRawIteratorWithThreadMode, Direction, Error,
-    IteratorMode, MultiThreaded, Options, ReadOptions, SingleThreaded, SnapshotWithThreadMode,
-    ThreadMode, Transaction, TransactionDBOptions, TransactionOptions, WriteBatchWithTransaction,
-    FlushOptions, WriteOptions, DB, DEFAULT_COLUMN_FAMILY_NAME,
+    FlushOptions, IteratorMode, MultiThreaded, Options, ReadOptions, SingleThreaded,
+    SnapshotWithThreadMode, ThreadMode, Transaction, TransactionDBOptions, TransactionOptions,
+    WriteBatchWithTransaction, WriteOptions, DB, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use ffi::rocksdb_transaction_t;
 use libc::{c_char, c_int, c_uchar, c_void, size_t};
@@ -423,6 +423,50 @@ impl<T: ThreadMode> TransactionDB<T> {
     /// Flushes database memtables to SST files on the disk using default options.
     pub fn flush(&self) -> Result<(), Error> {
         self.flush_opt(&FlushOptions::default())
+    }
+
+    /// Flushes database memtables to SST files on the disk for a given column family.
+    pub fn flush_cf_opt(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        flushopts: &FlushOptions,
+    ) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_transactiondb_flush_cf(
+                self.inner,
+                flushopts.inner,
+                cf.inner()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Flushes multiple column families.
+    ///
+    /// If atomic flush is not enabled, it is equivalent to calling flush_cf multiple times.
+    /// If atomic flush is enabled, it will flush all column families specified in `cfs` up to the latest sequence
+    /// number at the time when flush is requested.
+    pub fn flush_cfs_opt(
+        &self,
+        cfs: &[&impl AsColumnFamilyRef],
+        opts: &FlushOptions,
+    ) -> Result<(), Error> {
+        let mut cfs = cfs.iter().map(|cf| cf.inner()).collect::<Vec<_>>();
+        unsafe {
+            ffi_try!(ffi::rocksdb_transactiondb_flush_cfs(
+                self.inner,
+                opts.inner,
+                cfs.as_mut_ptr(),
+                cfs.len() as c_int,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Flushes database memtables to SST files on the disk for a given column family using default
+    /// options.
+    pub fn flush_cf(&self, cf: &impl AsColumnFamilyRef) -> Result<(), Error> {
+        self.flush_cf_opt(cf, &FlushOptions::default())
     }
 
     /// Creates a transaction with default options.

--- a/tests/test_transaction_db.rs
+++ b/tests/test_transaction_db.rs
@@ -18,8 +18,8 @@ mod util;
 use pretty_assertions::assert_eq;
 
 use rocksdb::{
-    CuckooTableOptions, DBAccess, Direction, Error, ErrorKind, IteratorMode, Options, ReadOptions,
-    SliceTransform, TransactionDB, TransactionDBOptions, TransactionOptions,
+    CuckooTableOptions, DBAccess, Direction, Error, ErrorKind, FlushOptions, IteratorMode, Options,
+    ReadOptions, SliceTransform, TransactionDB, TransactionDBOptions, TransactionOptions,
     WriteBatchWithTransaction, WriteOptions, DB,
 };
 use util::DBPath;
@@ -673,6 +673,89 @@ fn two_phase_commit() {
 
         assert_eq!(db.get(b"k1").unwrap().unwrap(), b"v1");
         assert!(db.get(b"k2").unwrap().is_none());
+    }
+}
+
+#[test]
+fn transaction_db_flush() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush");
+    {
+        let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+
+        let txn = db.transaction();
+        txn.put(b"k1", b"v1").unwrap();
+        txn.commit().unwrap();
+
+        // flush memtables to SST
+        db.flush().unwrap();
+
+        // verify data survived the flush
+        assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+}
+
+#[test]
+fn transaction_db_flush_opt() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_opt");
+    {
+        let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+
+        let txn = db.transaction();
+        txn.put(b"k1", b"v1").unwrap();
+        txn.commit().unwrap();
+
+        // flush with wait disabled (async flush)
+        let mut opts = FlushOptions::default();
+        opts.set_wait(false);
+        db.flush_opt(&opts).unwrap();
+
+        // wait for background flush to complete
+        let mut wait_opts = FlushOptions::default();
+        wait_opts.set_wait(true);
+        db.flush_opt(&wait_opts).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+}
+
+#[test]
+fn transaction_db_flush_wal() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_wal");
+    {
+        let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+
+        let txn = db.transaction();
+        txn.put(b"k1", b"v1").unwrap();
+        txn.commit().unwrap();
+
+        // sync WAL to disk
+        db.flush_wal(true).unwrap();
+
+        // verify data survived the WAL sync
+        assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+
+    // reopen and verify persistence
+    {
+        let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+        assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+}
+
+#[test]
+fn transaction_db_flush_wal_without_sync() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_wal_no_sync");
+    {
+        let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+
+        let txn = db.transaction();
+        txn.put(b"k1", b"v1").unwrap();
+        txn.commit().unwrap();
+
+        // flush WAL buffer without fsync
+        db.flush_wal(false).unwrap();
+
+        assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
     }
 }
 

--- a/tests/test_transaction_db.rs
+++ b/tests/test_transaction_db.rs
@@ -709,7 +709,9 @@ fn transaction_db_flush_opt() {
         opts.set_wait(false);
         db.flush_opt(&opts).unwrap();
 
-        // wait for background flush to complete
+        // issue a second synchronous flush; because the memtable was already
+        // flushed (or is in progress), this effectively acts as a barrier
+        // that ensures all previous flush work is complete before we assert
         let mut wait_opts = FlushOptions::default();
         wait_opts.set_wait(true);
         db.flush_opt(&wait_opts).unwrap();
@@ -756,6 +758,86 @@ fn transaction_db_flush_wal_without_sync() {
         db.flush_wal(false).unwrap();
 
         assert_eq!(db.get(b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+    // No reopen check: flush_wal(false) only flushes the in-process WAL
+    // buffer without calling fsync, so durability across a crash is not
+    // guaranteed. Verifying that already-open reads still work is the
+    // meaningful assertion for this code path.
+}
+
+#[test]
+fn transaction_db_flush_cf() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_cf");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db: TransactionDB =
+            TransactionDB::open_cf(&opts, &TransactionDBOptions::default(), &path, ["cf1"])
+                .unwrap();
+
+        let cf1 = db.cf_handle("cf1").unwrap();
+        db.put_cf(&cf1, b"k1", b"v1").unwrap();
+
+        db.flush_cf(&cf1).unwrap();
+
+        assert_eq!(db.get_cf(&cf1, b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+}
+
+#[test]
+fn transaction_db_flush_cf_opt() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_cf_opt");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db: TransactionDB =
+            TransactionDB::open_cf(&opts, &TransactionDBOptions::default(), &path, ["cf1"])
+                .unwrap();
+
+        let cf1 = db.cf_handle("cf1").unwrap();
+        db.put_cf(&cf1, b"k1", b"v1").unwrap();
+
+        // flush with wait disabled (async flush)
+        let mut flush_opts = FlushOptions::default();
+        flush_opts.set_wait(false);
+        db.flush_cf_opt(&cf1, &flush_opts).unwrap();
+
+        // synchronous flush as barrier to ensure async flush is complete
+        let mut wait_opts = FlushOptions::default();
+        wait_opts.set_wait(true);
+        db.flush_cf_opt(&cf1, &wait_opts).unwrap();
+
+        assert_eq!(db.get_cf(&cf1, b"k1").unwrap().unwrap().as_slice(), b"v1");
+    }
+}
+
+#[test]
+fn transaction_db_flush_cfs_opt() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_flush_cfs_opt");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db: TransactionDB = TransactionDB::open_cf(
+            &opts,
+            &TransactionDBOptions::default(),
+            &path,
+            ["cf1", "cf2"],
+        )
+        .unwrap();
+
+        let cf1 = db.cf_handle("cf1").unwrap();
+        let cf2 = db.cf_handle("cf2").unwrap();
+        db.put_cf(&cf1, b"k1", b"v1").unwrap();
+        db.put_cf(&cf2, b"k2", b"v2").unwrap();
+
+        let flush_opts = FlushOptions::default();
+        db.flush_cfs_opt(&[&cf1, &cf2], &flush_opts).unwrap();
+
+        assert_eq!(db.get_cf(&cf1, b"k1").unwrap().unwrap().as_slice(), b"v1");
+        assert_eq!(db.get_cf(&cf2, b"k2").unwrap().unwrap().as_slice(), b"v2");
     }
 }
 


### PR DESCRIPTION
Adding rocksdb_transactiondb_flush_wal and rocksdb_transactiondb_flush API wrappers.

Usage example:

```rs
let db: TransactionDB = TransactionDB::open_default(path)?;

let txn = db.transaction();
txn.put(b"title", b"hello_from_rust")?;
txn.commit()?;

db.flush_wal(true)?;
db.flush()?;
```

The tests are essentially just smoke tests that validate that the API can be called without any panics as there isn't the test infra to go deeper, but I'm using the feature in a DB I'm working on and I have tested it there and works. 