### PR TITLE
Add column-family-aware repair APIs

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -381,6 +381,7 @@ fn build_rocksdb() {
     }
 
     config.file("build_version.cc");
+    config.file("repair_db_cf.cc");
 
     config.cpp(true);
 

--- a/librocksdb-sys/repair_db_cf.cc
+++ b/librocksdb-sys/repair_db_cf.cc
@@ -1,0 +1,80 @@
+#include "rocksdb/c.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "rocksdb/db.h"
+#include "rocksdb/options.h"
+#include "rocksdb/status.h"
+
+using ROCKSDB_NAMESPACE::ColumnFamilyDescriptor;
+using ROCKSDB_NAMESPACE::ColumnFamilyOptions;
+using ROCKSDB_NAMESPACE::DBOptions;
+using ROCKSDB_NAMESPACE::Options;
+using ROCKSDB_NAMESPACE::RepairDB;
+using ROCKSDB_NAMESPACE::Status;
+
+struct rocksdb_options_t {
+  Options rep;
+};
+
+namespace {
+
+bool SaveError(char** errptr, const Status& status) {
+  if (status.ok()) {
+    return false;
+  }
+
+  if (errptr == nullptr) {
+    return true;
+  }
+
+  if (*errptr != nullptr) {
+    std::free(*errptr);
+  }
+  *errptr = ::strdup(status.ToString().c_str());
+  return true;
+}
+
+std::vector<ColumnFamilyDescriptor> BuildColumnFamilies(
+    int num_column_families, const char* const* column_family_names,
+    const rocksdb_options_t* const* column_family_options) {
+  std::vector<ColumnFamilyDescriptor> column_families;
+  column_families.reserve(static_cast<size_t>(num_column_families));
+  for (int i = 0; i < num_column_families; ++i) {
+    column_families.emplace_back(
+        std::string(column_family_names[i]),
+        ColumnFamilyOptions(column_family_options[i]->rep));
+  }
+  return column_families;
+}
+
+}  // namespace
+
+extern "C" {
+
+void rocksdb_repair_db_cf_descriptors(
+    const rocksdb_options_t* db_options, const char* name,
+    int num_column_families, const char* const* column_family_names,
+    const rocksdb_options_t* const* column_family_options, char** errptr) {
+  const auto column_families = BuildColumnFamilies(
+      num_column_families, column_family_names, column_family_options);
+  SaveError(errptr,
+            RepairDB(std::string(name), DBOptions(db_options->rep), column_families));
+}
+
+void rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
+    const rocksdb_options_t* db_options, const char* name,
+    int num_column_families, const char* const* column_family_names,
+    const rocksdb_options_t* const* column_family_options,
+    const rocksdb_options_t* unknown_cf_options, char** errptr) {
+  const auto column_families = BuildColumnFamilies(
+      num_column_families, column_family_names, column_family_options);
+  SaveError(errptr,
+            RepairDB(std::string(name), DBOptions(db_options->rep),
+                     column_families, ColumnFamilyOptions(unknown_cf_options->rep)));
+}
+
+}  // extern "C"

--- a/librocksdb-sys/repair_db_cf.cc
+++ b/librocksdb-sys/repair_db_cf.cc
@@ -65,16 +65,4 @@ void rocksdb_repair_db_cf_descriptors(
             RepairDB(std::string(name), DBOptions(db_options->rep), column_families));
 }
 
-void rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
-    const rocksdb_options_t* db_options, const char* name,
-    int num_column_families, const char* const* column_family_names,
-    const rocksdb_options_t* const* column_family_options,
-    const rocksdb_options_t* unknown_cf_options, char** errptr) {
-  const auto column_families = BuildColumnFamilies(
-      num_column_families, column_family_names, column_family_options);
-  SaveError(errptr,
-            RepairDB(std::string(name), DBOptions(db_options->rep),
-                     column_families, ColumnFamilyOptions(unknown_cf_options->rep)));
-}
-
 }  // extern "C"

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -33,5 +33,26 @@ extern crate zstd_sys;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+unsafe extern "C" {
+    pub fn rocksdb_repair_db_cf_descriptors(
+        db_options: *const rocksdb_options_t,
+        name: *const ::libc::c_char,
+        num_column_families: ::libc::c_int,
+        column_family_names: *const *const ::libc::c_char,
+        column_family_options: *const *const rocksdb_options_t,
+        errptr: *mut *mut ::libc::c_char,
+    );
+
+    pub fn rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
+        db_options: *const rocksdb_options_t,
+        name: *const ::libc::c_char,
+        num_column_families: ::libc::c_int,
+        column_family_names: *const *const ::libc::c_char,
+        column_family_options: *const *const rocksdb_options_t,
+        unknown_cf_options: *const rocksdb_options_t,
+        errptr: *mut *mut ::libc::c_char,
+    );
+}
+
 #[cfg(test)]
 mod test;

--- a/librocksdb-sys/src/lib.rs
+++ b/librocksdb-sys/src/lib.rs
@@ -42,16 +42,6 @@ unsafe extern "C" {
         column_family_options: *const *const rocksdb_options_t,
         errptr: *mut *mut ::libc::c_char,
     );
-
-    pub fn rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
-        db_options: *const rocksdb_options_t,
-        name: *const ::libc::c_char,
-        num_column_families: ::libc::c_int,
-        column_family_names: *const *const ::libc::c_char,
-        column_family_options: *const *const rocksdb_options_t,
-        unknown_cf_options: *const rocksdb_options_t,
-        errptr: *mut *mut ::libc::c_char,
-    );
 }
 
 #[cfg(test)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -961,39 +961,6 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         P: AsRef<Path>,
         I: IntoIterator<Item = ColumnFamilyDescriptor>,
     {
-        Self::repair_cf_descriptors_internal(opts, path, cfs, None)
-    }
-
-    /// Repairs a database using the provided column family descriptors and
-    /// fallback options for unknown column families discovered during repair.
-    ///
-    /// This matches RocksDB's `RepairDB(..., column_families, unknown_cf_opts)`
-    /// overload. Use it when the manifest may reference column families not
-    /// included in `cfs`, but they should still be repaired with a known set of
-    /// options.
-    pub fn repair_cf_descriptors_with_unknown_cf_opts<P, I>(
-        opts: &Options,
-        path: P,
-        cfs: I,
-        unknown_cf_opts: &Options,
-    ) -> Result<(), Error>
-    where
-        P: AsRef<Path>,
-        I: IntoIterator<Item = ColumnFamilyDescriptor>,
-    {
-        Self::repair_cf_descriptors_internal(opts, path, cfs, Some(unknown_cf_opts))
-    }
-
-    fn repair_cf_descriptors_internal<P, I>(
-        opts: &Options,
-        path: P,
-        cfs: I,
-        unknown_cf_opts: Option<&Options>,
-    ) -> Result<(), Error>
-    where
-        P: AsRef<Path>,
-        I: IntoIterator<Item = ColumnFamilyDescriptor>,
-    {
         let cpath = to_cpath(path)?;
         let cfs: Vec<_> = cfs.into_iter().collect();
 
@@ -1013,29 +980,13 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         })?;
 
         unsafe {
-            match unknown_cf_opts {
-                Some(unknown_cf_opts) => {
-                    ffi_try!(
-                        ffi::rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
-                            opts.inner,
-                            cpath.as_ptr(),
-                            num_column_families,
-                            cfnames.as_ptr(),
-                            cfopts.as_ptr(),
-                            unknown_cf_opts.inner,
-                        )
-                    );
-                }
-                None => {
-                    ffi_try!(ffi::rocksdb_repair_db_cf_descriptors(
-                        opts.inner,
-                        cpath.as_ptr(),
-                        num_column_families,
-                        cfnames.as_ptr(),
-                        cfopts.as_ptr(),
-                    ));
-                }
-            }
+            ffi_try!(ffi::rocksdb_repair_db_cf_descriptors(
+                opts.inner,
+                cpath.as_ptr(),
+                num_column_families,
+                cfnames.as_ptr(),
+                cfopts.as_ptr(),
+            ));
         }
         Ok(())
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -950,6 +950,96 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         Ok(())
     }
 
+    /// Repairs a database using the provided column family descriptors.
+    ///
+    /// This exposes RocksDB's column-family-aware repair path, which is needed
+    /// when column families use different options. The descriptors should
+    /// include the `default` column family. `Options::load_latest()` can be
+    /// used to recover a matching set of descriptors from an `OPTIONS-*` file.
+    pub fn repair_cf_descriptors<P, I>(opts: &Options, path: P, cfs: I) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        Self::repair_cf_descriptors_internal(opts, path, cfs, None)
+    }
+
+    /// Repairs a database using the provided column family descriptors and
+    /// fallback options for unknown column families discovered during repair.
+    ///
+    /// This matches RocksDB's `RepairDB(..., column_families, unknown_cf_opts)`
+    /// overload. Use it when the manifest may reference column families not
+    /// included in `cfs`, but they should still be repaired with a known set of
+    /// options.
+    pub fn repair_cf_descriptors_with_unknown_cf_opts<P, I>(
+        opts: &Options,
+        path: P,
+        cfs: I,
+        unknown_cf_opts: &Options,
+    ) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        Self::repair_cf_descriptors_internal(opts, path, cfs, Some(unknown_cf_opts))
+    }
+
+    fn repair_cf_descriptors_internal<P, I>(
+        opts: &Options,
+        path: P,
+        cfs: I,
+        unknown_cf_opts: Option<&Options>,
+    ) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        let cpath = to_cpath(path)?;
+        let cfs: Vec<_> = cfs.into_iter().collect();
+
+        let c_cfs: Result<Vec<_>, _> = cfs
+            .iter()
+            .map(|cf| CString::new(cf.name.as_bytes()))
+            .collect();
+        let c_cfs = c_cfs.map_err(|err| {
+            Error::new(format!(
+                "Failed to convert column family name to CString: {err}"
+            ))
+        })?;
+        let cfnames: Vec<_> = c_cfs.iter().map(|cf| cf.as_ptr()).collect();
+        let cfopts: Vec<_> = cfs.iter().map(|cf| cf.options.inner.cast_const()).collect();
+        let num_column_families = c_int::try_from(cfs.len()).map_err(|_| {
+            Error::new("Too many column families to pass through the C API.".to_owned())
+        })?;
+
+        unsafe {
+            match unknown_cf_opts {
+                Some(unknown_cf_opts) => {
+                    ffi_try!(
+                        ffi::rocksdb_repair_db_cf_descriptors_with_unknown_cf_options(
+                            opts.inner,
+                            cpath.as_ptr(),
+                            num_column_families,
+                            cfnames.as_ptr(),
+                            cfopts.as_ptr(),
+                            unknown_cf_opts.inner,
+                        )
+                    );
+                }
+                None => {
+                    ffi_try!(ffi::rocksdb_repair_db_cf_descriptors(
+                        opts.inner,
+                        cpath.as_ptr(),
+                        num_column_families,
+                        cfnames.as_ptr(),
+                        cfopts.as_ptr(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub fn path(&self) -> &Path {
         self.path.as_path()
     }

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -401,19 +401,6 @@ impl<T: ThreadMode> TransactionDB<T> {
         DB::repair_cf_descriptors(opts, path, cfs)
     }
 
-    pub fn repair_cf_descriptors_with_unknown_cf_opts<P, I>(
-        opts: &Options,
-        path: P,
-        cfs: I,
-        unknown_cf_opts: &Options,
-    ) -> Result<(), Error>
-    where
-        P: AsRef<Path>,
-        I: IntoIterator<Item = ColumnFamilyDescriptor>,
-    {
-        DB::repair_cf_descriptors_with_unknown_cf_opts(opts, path, cfs, unknown_cf_opts)
-    }
-
     pub fn path(&self) -> &Path {
         self.path.as_path()
     }

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -393,6 +393,27 @@ impl<T: ThreadMode> TransactionDB<T> {
         DB::repair(opts, path)
     }
 
+    pub fn repair_cf_descriptors<P, I>(opts: &Options, path: P, cfs: I) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        DB::repair_cf_descriptors(opts, path, cfs)
+    }
+
+    pub fn repair_cf_descriptors_with_unknown_cf_opts<P, I>(
+        opts: &Options,
+        path: P,
+        cfs: I,
+        unknown_cf_opts: &Options,
+    ) -> Result<(), Error>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = ColumnFamilyDescriptor>,
+    {
+        DB::repair_cf_descriptors_with_unknown_cf_opts(opts, path, cfs, unknown_cf_opts)
+    }
+
     pub fn path(&self) -> &Path {
         self.path.as_path()
     }

--- a/tests/test_repair.rs
+++ b/tests/test_repair.rs
@@ -1,0 +1,117 @@
+mod util;
+
+use std::cmp::Ordering;
+use std::fs;
+use std::path::Path;
+
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, Options, DB, DEFAULT_COLUMN_FAMILY_NAME};
+use util::DBPath;
+
+fn reverse_cf_options() -> Options {
+    let mut opts = Options::default();
+    opts.set_comparator(
+        "test_repair.reverse",
+        Box::new(|left: &[u8], right: &[u8]| match left.cmp(right) {
+            Ordering::Less => Ordering::Greater,
+            Ordering::Equal => Ordering::Equal,
+            Ordering::Greater => Ordering::Less,
+        }),
+    );
+    opts
+}
+
+fn repair_descriptors() -> Vec<ColumnFamilyDescriptor> {
+    vec![
+        ColumnFamilyDescriptor::new(DEFAULT_COLUMN_FAMILY_NAME, Options::default()),
+        ColumnFamilyDescriptor::new("reverse", reverse_cf_options()),
+    ]
+}
+
+fn remove_manifest_files(path: &Path) {
+    for entry in fs::read_dir(path).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with("MANIFEST-") {
+            fs::remove_file(entry.path()).unwrap();
+        }
+    }
+}
+
+#[test]
+fn repair_cf_descriptors_preserves_per_cf_options() {
+    let path = DBPath::new("_rust_rocksdb_repair_cf_descriptors");
+
+    let mut db_opts = Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+
+    {
+        let db = DB::open_cf_descriptors(&db_opts, &path, repair_descriptors()).unwrap();
+        let reverse_cf = db.cf_handle("reverse").unwrap();
+
+        db.put(b"default-flushed", b"v0").unwrap();
+        db.flush().unwrap();
+        db.put(b"default-wal", b"v1").unwrap();
+
+        db.put_cf(&reverse_cf, b"a", b"va").unwrap();
+        db.flush_cf(&reverse_cf).unwrap();
+        db.put_cf(&reverse_cf, b"b", b"vb").unwrap();
+    }
+
+    remove_manifest_files((&path).as_ref());
+
+    DB::repair_cf_descriptors(&db_opts, &path, repair_descriptors()).unwrap();
+
+    {
+        let db = DB::open_cf_descriptors(&db_opts, &path, repair_descriptors()).unwrap();
+        let reverse_cf = db.cf_handle("reverse").unwrap();
+
+        assert_eq!(db.get(b"default-flushed").unwrap().unwrap(), b"v0");
+        assert_eq!(db.get(b"default-wal").unwrap().unwrap(), b"v1");
+        assert_eq!(db.get_cf(&reverse_cf, b"a").unwrap().unwrap(), b"va");
+        assert_eq!(db.get_cf(&reverse_cf, b"b").unwrap().unwrap(), b"vb");
+
+        let repaired_keys = db
+            .iterator_cf(&reverse_cf, IteratorMode::Start)
+            .map(|item| item.unwrap().0)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            repaired_keys,
+            vec![
+                b"b".to_vec().into_boxed_slice(),
+                b"a".to_vec().into_boxed_slice()
+            ]
+        );
+    }
+}
+
+#[test]
+fn repair_cf_descriptors_requires_default_descriptor() {
+    let path = DBPath::new("_rust_rocksdb_repair_cf_requires_default");
+
+    let mut db_opts = Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+
+    {
+        let db = DB::open_cf_descriptors(&db_opts, &path, repair_descriptors()).unwrap();
+        let reverse_cf = db.cf_handle("reverse").unwrap();
+        db.put_cf(&reverse_cf, b"a", b"va").unwrap();
+        db.flush_cf(&reverse_cf).unwrap();
+    }
+
+    remove_manifest_files((&path).as_ref());
+
+    let err = DB::repair_cf_descriptors(
+        &db_opts,
+        &path,
+        [ColumnFamilyDescriptor::new("reverse", reverse_cf_options())],
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("Must contain entry for default column family"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- add `DB::repair_cf_descriptors(...)` to expose RocksDB
- add a matching `TransactionDB` forwarding method
- add a small `librocksdb-sys` C++ shim for the column-family-aware `RepairDB` overload
- add integration tests covering per-CF repair behavior and missing-default validation

## Why

The existing Rust API only exposed the single-`Options` repair path through `rocksdb_repair_db`, which cannot pass per-column-family options into RocksDB repair. This blocks correct repair of databases where column families use different options.

## Impact

- callers can now repair multi-CF databases with the same descriptor type already used for open APIs
- callers that load descriptors from `Options::load_latest()` can pass them directly into repair

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test --test test_repair -- --nocapture`
- `cargo test --test test_rocksdb_options test_load_latest -- --nocapture`
