### PR TITLE
Add TransactionDB checkpoint support

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -17,7 +17,7 @@
 //!
 //! [1]: https://github.com/facebook/rocksdb/wiki/Checkpoints
 
-use crate::{db::DBInner, ffi, ffi_util::to_cpath, DBCommon, Error, ThreadMode};
+use crate::{db::DBInner, ffi, ffi_util::to_cpath, DBCommon, Error, ThreadMode, TransactionDB};
 use std::{marker::PhantomData, path::Path};
 
 /// Default value for the `log_size_for_flush` parameter passed to
@@ -142,6 +142,78 @@ impl<'db> Checkpoint<'db> {
 }
 
 impl Drop for Checkpoint<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_checkpoint_object_destroy(self.inner);
+        }
+    }
+}
+
+/// TransactionDB checkpoint object.
+///
+/// Used to create physical checkpoints of a [`TransactionDB`].
+pub struct TransactionDBCheckpoint<'db> {
+    inner: *mut ffi::rocksdb_checkpoint_t,
+    _db: PhantomData<&'db ()>,
+}
+
+impl<'db> TransactionDBCheckpoint<'db> {
+    /// Creates a new checkpoint object for the specified [`TransactionDB`].
+    ///
+    /// Does not actually produce checkpoints, call `.create_checkpoint()` or
+    /// `.create_checkpoint_with_log_size()` to produce a DB checkpoint.
+    pub fn new<T: ThreadMode>(db: &'db TransactionDB<T>) -> Result<Self, Error> {
+        let checkpoint: *mut ffi::rocksdb_checkpoint_t;
+
+        unsafe {
+            checkpoint = ffi_try!(ffi::rocksdb_transactiondb_checkpoint_object_create(
+                db.inner
+            ));
+        }
+
+        if checkpoint.is_null() {
+            return Err(Error::new(
+                "Could not create TransactionDB checkpoint object.".to_owned(),
+            ));
+        }
+
+        Ok(Self {
+            inner: checkpoint,
+            _db: PhantomData,
+        })
+    }
+
+    /// Creates a new physical RocksDB checkpoint in the directory specified by `path`.
+    ///
+    /// See [`Checkpoint::create_checkpoint`] for details on checkpoint behavior and
+    /// the default `log_size_for_flush` value.
+    pub fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        self.create_checkpoint_with_log_size(path, DEFAULT_LOG_SIZE_FOR_FLUSH)
+    }
+
+    /// Creates a new physical RocksDB checkpoint in `path`, allowing the caller to
+    /// control `log_size_for_flush`.
+    ///
+    /// See [`Checkpoint::create_checkpoint_with_log_size`] for the semantics of
+    /// `log_size_for_flush`.
+    pub fn create_checkpoint_with_log_size<P: AsRef<Path>>(
+        &self,
+        path: P,
+        log_size_for_flush: u64,
+    ) -> Result<(), Error> {
+        let cpath = to_cpath(path)?;
+        unsafe {
+            ffi_try!(ffi::rocksdb_checkpoint_create(
+                self.inner,
+                cpath.as_ptr(),
+                log_size_for_flush,
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TransactionDBCheckpoint<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_checkpoint_object_destroy(self.inner);

--- a/tests/test_checkpoint.rs
+++ b/tests/test_checkpoint.rs
@@ -16,7 +16,10 @@ mod util;
 
 use pretty_assertions::assert_eq;
 
-use rocksdb::{checkpoint::Checkpoint, OptimisticTransactionDB, Options, DB};
+use rocksdb::{
+    checkpoint::{Checkpoint, TransactionDBCheckpoint},
+    OptimisticTransactionDB, Options, TransactionDB, TransactionDBOptions, DB,
+};
 use std::fs;
 use util::DBPath;
 
@@ -339,6 +342,66 @@ pub fn test_optimistic_transaction_db_checkpoint_with_large_log_size_skips_flush
     // the WAL is replayed, restoring the memtable data.
     assert_eq!(
         cp_db.get(b"memtable_key").unwrap().unwrap(),
+        b"memtable_value"
+    );
+}
+
+#[test]
+pub fn test_transaction_db_checkpoint() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    let db: TransactionDB =
+        TransactionDB::open(&opts, &TransactionDBOptions::default(), &db_path).unwrap();
+
+    db.put(b"k1", b"v1").unwrap();
+    let txn = db.transaction();
+    txn.put(b"k2", b"v2").unwrap();
+    txn.commit().unwrap();
+
+    let checkpoint = TransactionDBCheckpoint::new(&db).unwrap();
+    let checkpoint_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    checkpoint.create_checkpoint(&checkpoint_path).unwrap();
+
+    let checkpoint_db: TransactionDB =
+        TransactionDB::open(&opts, &TransactionDBOptions::default(), &checkpoint_path).unwrap();
+
+    assert_eq!(checkpoint_db.get(b"k1").unwrap().unwrap(), b"v1");
+    assert_eq!(checkpoint_db.get(b"k2").unwrap().unwrap(), b"v2");
+}
+
+#[test]
+pub fn test_transaction_db_checkpoint_with_log_size() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_log_size_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    let db: TransactionDB =
+        TransactionDB::open(&opts, &TransactionDBOptions::default(), &db_path).unwrap();
+
+    db.put(b"first_key", b"first_value").unwrap();
+    db.put(b"memtable_key", b"memtable_value").unwrap();
+
+    let checkpoint = TransactionDBCheckpoint::new(&db).unwrap();
+    let checkpoint_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    checkpoint
+        .create_checkpoint_with_log_size(&checkpoint_path, 0)
+        .unwrap();
+
+    let checkpoint_db: TransactionDB =
+        TransactionDB::open(&opts, &TransactionDBOptions::default(), &checkpoint_path).unwrap();
+
+    assert_eq!(
+        checkpoint_db.get(b"first_key").unwrap().unwrap(),
+        b"first_value"
+    );
+    assert_eq!(
+        checkpoint_db.get(b"memtable_key").unwrap().unwrap(),
         b"memtable_value"
     );
 }


### PR DESCRIPTION
I've added a similar implementation to Checkpoint for `TransactionDB` to expose the internal `rocksdb_transactiondb_checkpoint_object_create` that's already implemented in `rocksdb-sys`.