### PR TITLE
get_updates_since: Allow polling WAL iterator for updates

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2287,16 +2287,17 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// Returns an iterator positioned at the first WriteBatch with a start sequence number
     /// greater than `seq_number`.
     ///
-    /// Use the iterator to retrieve each
-    /// (`u64`, `WriteBatch`) tuple, and then gather the individual puts and
-    /// deletes using the `WriteBatch::iterate()` function.
-    ///
-    /// Calling `get_updates_since()` with a sequence number that is out of
-    /// bounds will return a `NotFound` error. The iterator can return a `TryAgain` error if
-    /// a new WAL file was added after the iterator was started.
+    /// Use the iterator to retrieve each (`u64`, `WriteBatch`) tuple, and then gather the
+    /// individual puts and deletes using [`WriteBatch::iterate`]. [`DBWALIterator::next`] can be
+    /// polled for WAL updates after it returns `None`. This is more efficient than creating a new
+    /// iterator.
     ///
     /// The iterator starts one WriteBatch after the RocksDB C++ GetUpdatesSince function in some
     /// cases. The C++ version starts with the first batch that contains `seq_number`, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// * `NotFound`: `seq_number` is greater than the latest sequence number written.
     pub fn get_updates_since(&self, seq_number: u64) -> Result<DBWALIterator, Error> {
         unsafe {
             // rocksdb_wal_readoptions_t does not appear to have any functions

--- a/src/db.rs
+++ b/src/db.rs
@@ -2284,16 +2284,19 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         sizes
     }
 
-    /// Iterate over batches of write operations since a given sequence.
+    /// Returns an iterator positioned at the first WriteBatch with a start sequence number
+    /// greater than `seq_number`.
     ///
-    /// Produce an iterator that will provide the batches of write operations
-    /// that have occurred since the given sequence (see
-    /// `latest_sequence_number()`). Use the provided iterator to retrieve each
+    /// Use the iterator to retrieve each
     /// (`u64`, `WriteBatch`) tuple, and then gather the individual puts and
     /// deletes using the `WriteBatch::iterate()` function.
     ///
     /// Calling `get_updates_since()` with a sequence number that is out of
-    /// bounds will return an error.
+    /// bounds will return a `NotFound` error. The iterator can return a `TryAgain` error if
+    /// a new WAL file was added after the iterator was started.
+    ///
+    /// The iterator starts one WriteBatch after the RocksDB C++ GetUpdatesSince function in some
+    /// cases. The C++ version starts with the first batch that contains `seq_number`, if it exists.
     pub fn get_updates_since(&self, seq_number: u64) -> Result<DBWALIterator, Error> {
         unsafe {
             // rocksdb_wal_readoptions_t does not appear to have any functions
@@ -2305,10 +2308,8 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 seq_number,
                 opts
             ));
-            Ok(DBWALIterator {
-                inner: iter,
-                start_seq_number: seq_number,
-            })
+
+            Ok(DBWALIterator::new(iter, seq_number))
         }
     }
 

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -587,11 +587,23 @@ impl<'a, D: DBAccess> Into<DBRawIteratorWithThreadMode<'a, D>> for DBIteratorWit
 /// value is the sequence number of the associated write batch.
 ///
 pub struct DBWALIterator {
-    pub(crate) inner: *mut ffi::rocksdb_wal_iterator_t,
-    pub(crate) start_seq_number: u64,
+    inner: *mut ffi::rocksdb_wal_iterator_t,
+    start_seq_number: u64,
+    is_first: bool,
+    /// true if the iterator encountered an error.
+    has_errored: bool,
 }
 
 impl DBWALIterator {
+    pub(crate) fn new(inner: *mut ffi::rocksdb_wal_iterator_t, start_seq_number: u64) -> Self {
+        Self {
+            inner,
+            start_seq_number,
+            is_first: true,
+            has_errored: false,
+        }
+    }
+
     /// Returns `true` if the iterator is valid. An iterator is invalidated when
     /// it reaches the end of its defined range, or when it encounters an error.
     ///
@@ -618,40 +630,38 @@ impl Iterator for DBWALIterator {
     type Item = Result<(u64, WriteBatch), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if !self.valid() {
+        // Stop iterating after an error. This makes errors non-recoverable, which matches RocksDB.
+        // The C++ TransactionLogIterator stores the status and will never be valid again.
+        if self.has_errored {
             return None;
         }
 
-        let mut seq: u64 = 0;
-        let mut batch = WriteBatch {
-            inner: unsafe { ffi::rocksdb_wal_iter_get_batch(self.inner, &mut seq) },
-        };
-
-        // if the initial sequence number is what was requested we skip it to
-        // only provide changes *after* it
-        while seq <= self.start_seq_number {
+        // If not the first call: try to advance the iterator.
+        // This allows polling the iterator for changes at the end of the WAL.
+        if self.is_first {
+            self.is_first = false;
+        } else {
             unsafe {
                 ffi::rocksdb_wal_iter_next(self.inner);
             }
-
-            if !self.valid() {
-                return None;
-            }
-
-            // this drops which in turn frees the skipped batch
-            batch = WriteBatch {
-                inner: unsafe { ffi::rocksdb_wal_iter_get_batch(self.inner, &mut seq) },
-            };
         }
 
         if !self.valid() {
-            return self.status().err().map(Result::Err);
+            // Remember if the iterator encountered an error so we can stop iterating.
+            let status = self.status();
+            self.has_errored = status.is_err();
+            return status.err().map(Result::Err);
         }
 
-        // Seek to the next write batch.
-        // Note that WriteBatches live independently of the WAL iterator so this is safe to do
-        unsafe {
-            ffi::rocksdb_wal_iter_next(self.inner);
+        let mut seq: u64 = 0;
+        let batch = WriteBatch {
+            inner: unsafe { ffi::rocksdb_wal_iter_get_batch(self.inner, &mut seq) },
+        };
+
+        // backwards compatibility: rust-rocksdb skips the first batch if it contains seq_number.
+        // The RocksDB iterator only returns batches once, so this check must be part of next()
+        if seq <= self.start_seq_number {
+            return self.next();
         }
 
         Some(Ok((seq, batch)))

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -629,6 +629,15 @@ impl DBWALIterator {
 impl Iterator for DBWALIterator {
     type Item = Result<(u64, WriteBatch), Error>;
 
+    /// Returns the next WriteBatch.
+    ///
+    /// This function can be polled for WAL updates after it returns `None`, if no errors
+    /// were encounterd. If an error is returned, a new iterator must be created.
+    ///
+    /// # Errors
+    ///
+    /// * `TryAgain`: if a new WAL file was created after the iterator was created. The caller
+    ///   should create a new iterator with [`DB::get_updates_since`] to continue reading the WAL.
     fn next(&mut self) -> Option<Self::Item> {
         // Stop iterating after an error. This makes errors non-recoverable, which matches RocksDB.
         // The C++ TransactionLogIterator stores the status and will never be valid again.
@@ -636,35 +645,35 @@ impl Iterator for DBWALIterator {
             return None;
         }
 
-        // If not the first call: try to advance the iterator.
-        // This allows polling the iterator for changes at the end of the WAL.
-        if self.is_first {
-            self.is_first = false;
-        } else {
-            unsafe {
-                ffi::rocksdb_wal_iter_next(self.inner);
+        loop {
+            // If not the first call: try to advance the iterator.
+            // This allows polling an iterator positioned at the end of the WAL for updates.
+            if self.is_first {
+                self.is_first = false;
+            } else {
+                unsafe {
+                    ffi::rocksdb_wal_iter_next(self.inner);
+                }
+            }
+
+            if !self.valid() {
+                // On error: the iterator returns the error, then None to stop iteration.
+                let status = self.status();
+                self.has_errored = status.is_err();
+                return status.err().map(Result::Err);
+            }
+
+            let mut seq: u64 = 0;
+            let batch = WriteBatch {
+                inner: unsafe { ffi::rocksdb_wal_iter_get_batch(self.inner, &mut seq) },
+            };
+
+            // backwards compatibility: rust-rocksdb skips the first batch if it contains seq_number.
+            // The RocksDB iterator only returns batches once, so this check must be part of next()
+            if seq > self.start_seq_number {
+                return Some(Ok((seq, batch)));
             }
         }
-
-        if !self.valid() {
-            // Remember if the iterator encountered an error so we can stop iterating.
-            let status = self.status();
-            self.has_errored = status.is_err();
-            return status.err().map(Result::Err);
-        }
-
-        let mut seq: u64 = 0;
-        let batch = WriteBatch {
-            inner: unsafe { ffi::rocksdb_wal_iter_get_batch(self.inner, &mut seq) },
-        };
-
-        // backwards compatibility: rust-rocksdb skips the first batch if it contains seq_number.
-        // The RocksDB iterator only returns batches once, so this check must be part of next()
-        if seq <= self.start_seq_number {
-            return self.next();
-        }
-
-        Some(Ok((seq, batch)))
     }
 }
 

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -630,13 +630,12 @@ fn test_get_updates_since_batches() {
     assert_eq!(start_seqs_since(&db, 4), empty);
     assert_eq!(start_seqs_since(&db, 5), empty);
 
-    // > latest_sequence_number fails with a NotFound error
+    // > latest_sequence_number: NotFound "Requested sequence not yet written in the db"
     assert_eq!(db.latest_sequence_number(), 5);
     match db.get_updates_since(6) {
         Ok(_) => panic!("expected iterator error"),
         Err(e) => {
             assert!(matches!(e.kind(), ErrorKind::NotFound));
-            assert!(e.to_string().contains("not yet written"), "e={e}");
         }
     }
 }
@@ -687,7 +686,7 @@ fn test_get_updates_since_poll_iterator() {
     assert_eq!(batch.len(), 1);
     assert!(iter.next().is_none());
 
-    // force a WAL file rotation: returns a TryAgain error
+    // Cause a TryAgain error: flush writes the current memtable and starts a new one with a new WAL
     db.flush().unwrap();
 
     db.put(b"key3", b"value3").unwrap();
@@ -697,10 +696,8 @@ fn test_get_updates_since_poll_iterator() {
             panic!("expected iterator to return an error");
         }
         Some(Err(e)) => {
+            // "Create a new iterator to fetch the new tail"
             assert!(matches!(e.kind(), ErrorKind::TryAgain));
-            assert!(e
-                .to_string()
-                .contains("Create a new iterator to fetch the new tail"));
         }
         None => panic!("unexpected end of iterator"),
     };

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -580,6 +580,17 @@ fn test_get_updates_since_one_batch() {
     }
 }
 
+/// Returns the WriteBatch sequence numbers from `get_updates_since(seq_number)`.
+fn start_seqs_since(db: &DB, seq_number: u64) -> Vec<u64> {
+    let iter = db.get_updates_since(seq_number).unwrap();
+    let mut start_seqs = Vec::new();
+    for iter_result in iter {
+        let (start_seq, _) = iter_result.expect("unexpected iterator error");
+        start_seqs.push(start_seq);
+    }
+    start_seqs
+}
+
 #[test]
 fn test_get_updates_since_batches() {
     let path = DBPath::new("_rust_rocksdb_test_get_updates_since_one_batch");
@@ -610,6 +621,24 @@ fn test_get_updates_since_batches() {
     assert!(iter.next().is_none());
     assert_eq!(counts.puts, 2);
     assert_eq!(counts.deletes, 0);
+
+    assert_eq!(start_seqs_since(&db, 0), vec![1, 2, 4]);
+    assert_eq!(start_seqs_since(&db, 1), vec![2, 4]);
+    assert_eq!(start_seqs_since(&db, 2), vec![4]);
+    assert_eq!(start_seqs_since(&db, 3), vec![4]);
+    let empty: Vec<u64> = vec![];
+    assert_eq!(start_seqs_since(&db, 4), empty);
+    assert_eq!(start_seqs_since(&db, 5), empty);
+
+    // > latest_sequence_number fails with a NotFound error
+    assert_eq!(db.latest_sequence_number(), 5);
+    match db.get_updates_since(6) {
+        Ok(_) => panic!("expected iterator error"),
+        Err(e) => {
+            assert!(matches!(e.kind(), ErrorKind::NotFound));
+            assert!(e.to_string().contains("not yet written"), "e={e}");
+        }
+    }
 }
 
 #[test]
@@ -631,6 +660,56 @@ fn test_get_updates_since_out_of_range() {
     // get_updates_since() with an out of bounds sequence number
     let result = db.get_updates_since(1000);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_get_updates_since_poll_iterator() {
+    // Enable WAL archiving so the WAL files are preserved even after a flush
+    let mut opts = Options::default();
+    opts.set_wal_ttl_seconds(60 * 60);
+    opts.create_if_missing(true);
+    let path = DBPath::new("_rust_rocksdb_test_get_updates_since_poll_iterator");
+    let db = DB::open(&opts, &path).unwrap();
+    db.put(b"key1", b"value1").unwrap();
+
+    let mut iter = db.get_updates_since(0).unwrap();
+    let (seq, batch) = iter.next().unwrap().unwrap();
+    assert_eq!(seq, 1);
+    assert_eq!(batch.len(), 1);
+
+    // calling next returns None
+    assert!(iter.next().is_none());
+
+    // do an additional write: the iterator can continue and return it
+    db.put(b"key2", b"value2").unwrap();
+    let (seq, batch) = iter.next().unwrap().unwrap();
+    assert_eq!(seq, 2);
+    assert_eq!(batch.len(), 1);
+    assert!(iter.next().is_none());
+
+    // force a WAL file rotation: returns a TryAgain error
+    db.flush().unwrap();
+
+    db.put(b"key3", b"value3").unwrap();
+    assert_eq!(db.latest_sequence_number(), 3);
+    match iter.next() {
+        Some(Ok(_)) => {
+            panic!("expected iterator to return an error");
+        }
+        Some(Err(e)) => {
+            assert!(matches!(e.kind(), ErrorKind::TryAgain));
+            assert!(e
+                .to_string()
+                .contains("Create a new iterator to fetch the new tail"));
+        }
+        None => panic!("unexpected end of iterator"),
+    };
+    // next must return None after an error, and must stay None
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_none());
+
+    // a new iterator returns all the values
+    assert_eq!(start_seqs_since(&db, 0), vec![1, 2, 3]);
 }
 
 #[test]


### PR DESCRIPTION
The RocksDB C++ TransactionLogIterator allows polling the WAL for new changes by calling Next() then Valid(). This is much cheaper than recreating the iterator by calling GetUpdatesSince again, which has to reopen and seek in the WAL file. Restructure the Rust wrapper to allow it to be used in this way.

RocksDB tests this in TransactionLogIteratorStallAtLastRecord [1] with the following code (comments mine). This suggests this is a supported feature.

```c++
  // iterator is not valid: at end of WAL
  iter->Next();
  ASSERT_TRUE(!iter->Valid());
  ASSERT_OK(iter->status());

  // put value and advance the iterator: now valid
  ASSERT_OK(Put("key2", DummyString(1024)));
  iter->Next();
  ASSERT_OK(iter->status());
  ASSERT_TRUE(iter->Valid());
```

This change adds a similar test in test_get_updates_since_poll_iterator. I extended test_get_updates_since_batches to try to verify that this change preserves the existing start of the iterator, to not break existing applications.

[1] https://github.com/facebook/rocksdb/blob/2d68f304259d9271188033bf5faa7fd83e38552b/db/db_log_iter_test.cc#L195