### PR TITLE
fix cargo clippy cast warnings on linux aarch64

### DIFF
--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -128,14 +128,14 @@ where
     use self::Decision::{Change, Keep, Remove};
 
     let cb = unsafe { &mut *(raw_cb as *mut F) };
-    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_length) };
-    let oldval = unsafe { slice::from_raw_parts(existing_value as *const u8, value_length) };
+    let key = unsafe { slice::from_raw_parts(raw_key.cast::<u8>(), key_length) };
+    let oldval = unsafe { slice::from_raw_parts(existing_value.cast::<u8>(), value_length) };
     let result = cb.filter(level as u32, key, oldval);
     match result {
         Keep => 0,
         Remove => 1,
         Change(newval) => {
-            unsafe { *new_value = newval.as_ptr() as *mut c_char };
+            unsafe { *new_value = newval.as_ptr().cast_mut().cast::<c_char>() };
             unsafe { *new_value_length = newval.len() as size_t };
             unsafe { *value_changed = 1_u8 };
             0

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -48,8 +48,8 @@ impl ComparatorCallback {
         b_len: size_t,
     ) -> c_int {
         let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
-        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
-        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw.cast::<u8>(), a_len) };
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw.cast::<u8>(), b_len) };
         (cb.compare_fn)(a, b) as c_int
     }
 }
@@ -80,8 +80,8 @@ impl ComparatorWithTsCallback {
         b_len: size_t,
     ) -> c_int {
         let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
-        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
-        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw.cast::<u8>(), a_len) };
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw.cast::<u8>(), b_len) };
         (cb.compare_fn)(a, b) as c_int
     }
 
@@ -93,8 +93,8 @@ impl ComparatorWithTsCallback {
         b_ts_len: size_t,
     ) -> c_int {
         let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
-        let a_ts: &[u8] = unsafe { slice::from_raw_parts(a_ts_raw as *const u8, a_ts_len) };
-        let b_ts: &[u8] = unsafe { slice::from_raw_parts(b_ts_raw as *const u8, b_ts_len) };
+        let a_ts: &[u8] = unsafe { slice::from_raw_parts(a_ts_raw.cast::<u8>(), a_ts_len) };
+        let b_ts: &[u8] = unsafe { slice::from_raw_parts(b_ts_raw.cast::<u8>(), b_ts_len) };
         (cb.compare_ts_fn)(a_ts, b_ts) as c_int
     }
 
@@ -108,9 +108,9 @@ impl ComparatorWithTsCallback {
         b_has_ts_raw: c_uchar,
     ) -> c_int {
         let cb: &mut Self = unsafe { &mut *(raw_cb as *mut Self) };
-        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw as *const u8, a_len) };
+        let a: &[u8] = unsafe { slice::from_raw_parts(a_raw.cast::<u8>(), a_len) };
         let a_has_ts = a_has_ts_raw != 0;
-        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw as *const u8, b_len) };
+        let b: &[u8] = unsafe { slice::from_raw_parts(b_raw.cast::<u8>(), b_len) };
         let b_has_ts = b_has_ts_raw != 0;
         (cb.compare_without_ts_fn)(a, a_has_ts, b, b_has_ts) as c_int
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2595,7 +2595,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 Err(Error::new("Could not get full_history_ts_low".to_owned()))
             } else {
                 let mut vec = vec![0; ts_lowlen];
-                ptr::copy_nonoverlapping(ts as *mut u8, vec.as_mut_ptr(), ts_lowlen);
+                ptr::copy_nonoverlapping(ts.cast::<u8>(), vec.as_mut_ptr(), ts_lowlen);
                 ffi::rocksdb_free(ts as *mut c_void);
                 Ok(vec)
             }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -4812,7 +4812,7 @@ impl CompactOptions {
 
     fn set_full_history_ts_low_impl(&mut self, ts: Option<Vec<u8>>) {
         let (ptr, len) = if let Some(ref ts) = ts {
-            (ts.as_ptr() as *mut c_char, ts.len())
+            (ts.as_ptr().cast_mut().cast::<c_char>(), ts.len())
         } else if self.full_history_ts_low.is_some() {
             (std::ptr::null::<Vec<u8>>() as *mut c_char, 0)
         } else {
@@ -4980,7 +4980,7 @@ unsafe extern "C" fn logger_callback(
     len: size_t,
 ) {
     let rust_callback: &LoggerCallback = unsafe { &*(raw_cb as LoggerCallbackPtr) };
-    let raw_msg = unsafe { std::slice::from_raw_parts(msg as *const u8, len) };
+    let raw_msg = unsafe { std::slice::from_raw_parts(msg.cast::<u8>(), len) };
     let msg = String::from_utf8_lossy(raw_msg);
     let level =
         LogLevel::try_from_raw(level as i32).expect("rocksdb generated an invalid log level");

--- a/src/db_pinnable_slice.rs
+++ b/src/db_pinnable_slice.rs
@@ -44,7 +44,9 @@ impl Deref for DBPinnableSlice<'_> {
     fn deref(&self) -> &[u8] {
         unsafe {
             let mut val_len: size_t = 0;
-            let val = ffi::rocksdb_pinnableslice_value(self.ptr, &mut val_len) as *mut u8;
+            let val = ffi::rocksdb_pinnableslice_value(self.ptr, &mut val_len)
+                .cast_mut()
+                .cast::<u8>();
             slice::from_raw_parts(val, val_len)
         }
     }

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -40,7 +40,7 @@ pub(crate) unsafe fn raw_data(ptr: *const c_char, size: usize) -> Option<Vec<u8>
         None
     } else {
         let mut dst = vec![0; size];
-        unsafe { ptr::copy_nonoverlapping(ptr as *const u8, dst.as_mut_ptr(), size) };
+        unsafe { ptr::copy_nonoverlapping(ptr.cast::<u8>(), dst.as_mut_ptr(), size) };
 
         Some(dst)
     }
@@ -236,7 +236,7 @@ impl CSlice {
 
 impl AsRef<[u8]> for CSlice {
     fn as_ref(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) }
+        unsafe { std::slice::from_raw_parts(self.data.cast::<u8>(), self.len) }
     }
 }
 

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -90,7 +90,12 @@ pub unsafe extern "C" fn delete_callback(
     value_length: size_t,
 ) {
     if !value.is_null() {
-        drop(unsafe { Box::from_raw(slice::from_raw_parts_mut(value as *mut u8, value_length)) });
+        drop(unsafe {
+            Box::from_raw(slice::from_raw_parts_mut(
+                value.cast_mut().cast::<u8>(),
+                value_length,
+            ))
+        });
     }
 }
 
@@ -115,11 +120,11 @@ pub unsafe extern "C" fn full_merge_callback<F: MergeFn, PF: MergeFn>(
 ) -> *mut c_char {
     let cb = unsafe { &mut *(raw_cb as *mut MergeOperatorCallback<F, PF>) };
     let operands = &MergeOperands::new(operands_list, operands_list_len, num_operands);
-    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
+    let key = unsafe { slice::from_raw_parts(raw_key.cast::<u8>(), key_len) };
     let oldval = if existing_value.is_null() {
         None
     } else {
-        Some(unsafe { slice::from_raw_parts(existing_value as *const u8, existing_value_len) })
+        Some(unsafe { slice::from_raw_parts(existing_value.cast::<u8>(), existing_value_len) })
     };
     (cb.full_merge_fn)(key, oldval, operands).map_or_else(
         || {
@@ -147,7 +152,7 @@ pub unsafe extern "C" fn partial_merge_callback<F: MergeFn, PF: MergeFn>(
 ) -> *mut c_char {
     let cb = unsafe { &mut *(raw_cb as *mut MergeOperatorCallback<F, PF>) };
     let operands = &MergeOperands::new(operands_list, operands_list_len, num_operands);
-    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
+    let key = unsafe { slice::from_raw_parts(raw_key.cast::<u8>(), key_len) };
     (cb.partial_merge_fn)(key, None, operands).map_or_else(
         || {
             unsafe { *new_value_length = 0 };

--- a/src/slice_transform.rs
+++ b/src/slice_transform.rs
@@ -98,10 +98,10 @@ pub unsafe extern "C" fn transform_callback(
     dst_length: *mut size_t,
 ) -> *mut c_char {
     let cb = unsafe { &mut *(raw_cb as *mut TransformCallback) };
-    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
+    let key = unsafe { slice::from_raw_parts(raw_key.cast::<u8>(), key_len) };
     let prefix = (cb.transform_fn)(key);
     unsafe { *dst_length = prefix.len() as size_t };
-    prefix.as_ptr() as *mut c_char
+    prefix.as_ptr().cast::<c_char>().cast_mut()
 }
 
 pub unsafe extern "C" fn in_domain_callback(
@@ -110,6 +110,6 @@ pub unsafe extern "C" fn in_domain_callback(
     key_len: size_t,
 ) -> c_uchar {
     let cb = unsafe { &mut *(raw_cb as *mut TransformCallback) };
-    let key = unsafe { slice::from_raw_parts(raw_key as *const u8, key_len) };
+    let key = unsafe { slice::from_raw_parts(raw_key.cast::<u8>(), key_len) };
     c_uchar::from(cb.in_domain_fn.is_none_or(|in_domain| in_domain(key)))
 }

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -165,7 +165,7 @@ impl<DB> Transaction<'_, DB> {
                 None
             } else {
                 let mut vec = vec![0; name_len];
-                std::ptr::copy_nonoverlapping(name as *mut u8, vec.as_mut_ptr(), name_len);
+                std::ptr::copy_nonoverlapping(name.cast::<u8>(), vec.as_mut_ptr(), name_len);
                 ffi::rocksdb_free(name as *mut c_void);
                 Some(vec)
             }

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -95,8 +95,8 @@ unsafe extern "C" fn writebatch_put_callback<T: WriteBatchIterator>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.put(key, value);
     }
 }
@@ -108,7 +108,7 @@ unsafe extern "C" fn writebatch_delete_callback<T: WriteBatchIterator>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
         callbacks.delete(key);
     }
 }
@@ -123,8 +123,8 @@ unsafe extern "C" fn writebatch_put_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.put_cf(cfid, key, value);
     }
 }
@@ -137,7 +137,7 @@ unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
         callbacks.delete_cf(cfid, key);
     }
 }
@@ -152,8 +152,8 @@ unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.merge_cf(cfid, key, value);
     }
 }


### PR DESCRIPTION
This changes casts to make clippy pass on Linux aarch64. There are no behavior changes intended. On Linux aarch64, clippy warns about two categories of casts:

First: c_char_ptr as *const u8: On linux aarch64, char is u8, so this is an unnecessary cast and warns:
```
  warning: casting raw pointers to the same type and constness is
  unnecessary (`*const u8` -> `*const u8`)
```
The fix is to use c_char_ptr.cast::<u8>().

Second: u8_ptr as *mut c_char: On linux x86-64 this changes sign and const, but on linux aarch64 it only changes const, so it warns:
```
  warning: `as` casting between raw pointers while changing only its
  constness
```
The fix is to use u8_ptr.cast_mut().