### PR TITLE
Add ReadOptions deadline and IO timeout setters

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -4303,6 +4303,31 @@ impl ReadOptions {
         }
     }
 
+    /// Sets the deadline for completing an API call in microseconds since the
+    /// Unix epoch.
+    ///
+    /// This is best effort and applies to `Get`, `MultiGet`, `Seek`, and `Next`
+    /// operations.
+    ///
+    /// Default: 0
+    pub fn set_deadline(&mut self, microseconds: u64) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_deadline(self.inner, microseconds);
+        }
+    }
+
+    /// Sets the timeout for each underlying file read request in microseconds.
+    ///
+    /// Unlike `set_deadline`, this timeout applies to each individual read
+    /// request. A single RocksDB operation may issue multiple file reads.
+    ///
+    /// Default: 0
+    pub fn set_io_timeout(&mut self, microseconds: u64) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_io_timeout(self.inner, microseconds);
+        }
+    }
+
     /// If true, create a tailing iterator. Note that tailing iterators
     /// only support moving in the forward direction. Iterating in reverse
     /// or seek_to_last are not supported.

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -158,6 +158,8 @@ fn test_block_based_options() {
 fn test_read_options() {
     let mut read_opts = ReadOptions::default();
     read_opts.set_verify_checksums(false);
+    read_opts.set_deadline(1_000_000);
+    read_opts.set_io_timeout(500_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Expose `ReadOptions::set_deadline` for configuring per-operation read deadlines.
- Expose `ReadOptions::set_io_timeout` for configuring per-file-read IO timeouts.
- Add compile coverage for both setters in the existing read options test.

## Test Plan
- `cargo +1.88.0 fmt --check`
- `git diff --check`