### PR TITLE
Add set_cf_paths to allow per column family sst and blob paths

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1373,6 +1373,27 @@ impl Options {
         }
     }
 
+    /// A list of paths where SST files for this column family can be put
+    /// into, with its target size. Similar to `set_db_paths`, newer data is
+    /// placed into paths specified earlier in the vector while older data
+    /// gradually moves to paths specified later in the vector.
+    ///
+    /// Note that, if a path is supplied to multiple column families, it would
+    /// have files and total size from all the column families combined. User
+    /// should provision for the total size (from all the column families) in
+    /// such cases.
+    ///
+    /// If left empty, `db_paths` will be used.
+    ///
+    /// Default: empty
+    pub fn set_cf_paths(&mut self, paths: &[DBPath]) {
+        let mut paths: Vec<_> = paths.iter().map(|path| path.inner.cast_const()).collect();
+        let num_paths = paths.len();
+        unsafe {
+            ffi::rocksdb_options_set_cf_paths(self.inner, paths.as_mut_ptr(), num_paths);
+        }
+    }
+
     /// Use the specified object to interact with the environment,
     /// e.g. to read/write files, schedule background work, etc. In the near
     /// future, support for doing storage operations such as read/write files

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -18,8 +18,8 @@ use std::{fs, io::Read as _};
 
 use rocksdb::checkpoint::Checkpoint;
 use rocksdb::{
-    BlockBasedOptions, BlockBasedTablePinningTier, Cache, DBCompressionType, DataBlockIndexType,
-    Env, LruCacheOptions, Options, ReadOptions, DB,
+    BlockBasedOptions, BlockBasedTablePinningTier, Cache, ColumnFamilyDescriptor,
+    DBCompressionType, DataBlockIndexType, Env, LruCacheOptions, Options, ReadOptions, DB,
 };
 use util::DBPath;
 
@@ -646,4 +646,47 @@ fn test_crc32_build() {
         crc32_supported_arch, expected_arch,
         "Expected CRC32 support for architecture '{expected_arch}', but RocksDB reported support for '{crc32_supported_arch}'"
     );
+}
+
+#[test]
+fn test_set_cf_paths() {
+    let path = DBPath::new("_rust_rocksdb_test_set_cf_paths");
+    let cf_dir = (&path).as_ref().join("cf1_sst");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        let mut cf_opts = Options::default();
+        let cf_path = rocksdb::DBPath::new(&cf_dir, 0).unwrap();
+        cf_opts.set_cf_paths(&[cf_path]);
+
+        let db = DB::open_cf_descriptors(
+            &opts,
+            &path,
+            vec![ColumnFamilyDescriptor::new("cf1", cf_opts)],
+        )
+        .unwrap();
+        let cf1 = db.cf_handle("cf1").unwrap();
+        db.put_cf(&cf1, b"k1", b"v1").unwrap();
+        db.flush_cf(&cf1).unwrap();
+
+        assert_eq!(db.get_cf(&cf1, b"k1").unwrap().unwrap(), b"v1");
+
+        let has_sst = |dir: &std::path::Path| {
+            fs::read_dir(dir).is_ok_and(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .any(|entry| entry.path().extension().is_some_and(|ext| ext == "sst"))
+            })
+        };
+        assert!(
+            has_sst(&cf_dir),
+            "SST files for cf1 should be under its cf path"
+        );
+        assert!(
+            !has_sst((&path).as_ref()),
+            "no SST files should be under the DB path"
+        );
+    }
 }


### PR DESCRIPTION
Hi @aleksuss, small parity addition, would appreciate a review when you have a moment.

This PR adds a safe wrapper for `rocksdb_options_set_cf_paths`, the per-column-family counterpart of the existing `set_db_paths`. The C symbol is already exposed in the bundled RocksDB, so this is a pure Rust addition mirroring `set_db_paths`, plus a placement test.

We need this for https://github.com/spool-labs/tape. Storage nodes there typically have a small fast NVMe drive and large HDDs, and the store keeps small hot metadata/index column families next to bulk BlobDB column families holding large payloads. `cf_paths` lets us pin the bulk column families to the HDD while metadata and the WAL stay on the SSD. It is also the only way to steer integrated BlobDB data: blob files are always written to `cf_paths.front()`, and the old `blob_dir` option is stacked-BlobDB-only and not in the C API.

Without this binding the option is unreachable from safe code, since `Options.inner` is `pub(crate)` and the crate does not re-export `librocksdb_sys`.

Regards, 
miester