### PR TITLE
Add Options::set_cf_paths

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1253,6 +1253,25 @@ impl Options {
         }
     }
 
+    /// A list of paths where SST files for this column family can be put into,
+    /// with its target size. Similar to `db_paths`, newer data is placed into
+    /// paths specified earlier in the vector while older data gradually moves to
+    /// paths specified later in the vector.
+    ///
+    /// To place a whole column family on a specific disk, pass a single
+    /// [`DBPath`] with a target size large enough that it is never exceeded.
+    ///
+    /// If left empty, `db_paths` will be used.
+    ///
+    /// Default: empty
+    pub fn set_cf_paths(&mut self, paths: &[DBPath]) {
+        let mut paths: Vec<_> = paths.iter().map(|path| path.inner.cast_const()).collect();
+        let num_paths = paths.len();
+        unsafe {
+            ffi::rocksdb_options_set_cf_paths(self.inner, paths.as_mut_ptr(), num_paths);
+        }
+    }
+
     /// Use the specified object to interact with the environment,
     /// e.g. to read/write files, schedule background work, etc. In the near
     /// future, support for doing storage operations such as read/write files

--- a/tests/test_cf_paths.rs
+++ b/tests/test_cf_paths.rs
@@ -1,0 +1,66 @@
+mod util;
+
+use rocksdb::{ColumnFamilyDescriptor, DBPath as RocksDbPath, Options, DB};
+use std::fs;
+use std::path::Path;
+use util::DBPath;
+
+fn count_sst(dir: &Path) -> usize {
+    fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map_or(false, |x| x == "sst"))
+        .count()
+}
+
+// A column family with `set_cf_paths` set to a separate directory writes its SST files there,
+// not into the main DB directory, and the data still reads back.
+#[test]
+fn cf_paths_places_sst_on_separate_dir() {
+    let db_path = DBPath::new("_rust_rocksdb_cf_paths_test");
+    let cf_dir = tempfile::Builder::new()
+        .prefix("cf_tx")
+        .tempdir()
+        .expect("temp dir for the redirected column family");
+
+    {
+        let mut db_opts = Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+
+        // "default" column family: no override, stays in the DB directory.
+        let default_opts = Options::default();
+
+        // "col_tx": pin its SST files to a separate directory via a single large-target path.
+        let mut tx_opts = Options::default();
+        tx_opts.set_cf_paths(&[RocksDbPath::new(cf_dir.path(), u64::MAX).unwrap()]);
+
+        let cfs = vec![
+            ColumnFamilyDescriptor::new("default", default_opts),
+            ColumnFamilyDescriptor::new("col_tx", tx_opts),
+        ];
+        let db = DB::open_cf_descriptors(&db_opts, &db_path, cfs).unwrap();
+        let tx = db.cf_handle("col_tx").unwrap();
+
+        for i in 0..4000u32 {
+            db.put_cf(&tx, i.to_be_bytes(), vec![i as u8; 512]).unwrap();
+        }
+        db.flush_cf(&tx).unwrap();
+
+        assert_eq!(
+            db.get_cf(&tx, 42u32.to_be_bytes()).unwrap().unwrap(),
+            vec![42u8; 512],
+            "redirected column family reads back its data",
+        );
+    }
+
+    assert!(
+        count_sst(cf_dir.path()) > 0,
+        "column family SST files should be in the cf_paths override dir",
+    );
+    assert_eq!(
+        count_sst((&db_path).as_ref()),
+        0,
+        "no col_tx SST should be in the main DB dir (default CF got no writes)",
+    );
+}


### PR DESCRIPTION
Adds `Options::set_cf_paths`, wrapping the existing `rocksdb_options_set_cf_paths` FFI (already generated by librocksdb-sys). It mirrors `set_db_paths` but sets the per-column-family SST paths.

Motivation: to place one column family's SST files on a specific directory/disk, `cf_paths` is the intended RocksDB mechanism, but the safe wrapper was missing from the crate (only `set_db_paths` existed). Passing a single `DBPath` with a large target size pins a whole column family to one directory.

Includes a test that a column family opened with `cf_paths` set writes its SST files to the override directory and reads the data back.

Draft: opening for feedback on the API shape.