### PR TITLE
make ReadOptions::default() not allocate

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -220,7 +220,7 @@ impl<T: ThreadMode, D: DBInner> DBAccess for DBCommon<T, D> {
     }
 
     unsafe fn create_iterator(&self, readopts: &ReadOptions) -> *mut ffi::rocksdb_iterator_t {
-        unsafe { ffi::rocksdb_create_iterator(self.inner.inner(), readopts.inner) }
+        unsafe { ffi::rocksdb_create_iterator(self.inner.inner(), readopts.inner()) }
     }
 
     unsafe fn create_iterator_cf(
@@ -228,7 +228,7 @@ impl<T: ThreadMode, D: DBInner> DBAccess for DBCommon<T, D> {
         cf_handle: *mut ffi::rocksdb_column_family_handle_t,
         readopts: &ReadOptions,
     ) -> *mut ffi::rocksdb_iterator_t {
-        unsafe { ffi::rocksdb_create_iterator_cf(self.inner.inner(), readopts.inner, cf_handle) }
+        unsafe { ffi::rocksdb_create_iterator_cf(self.inner.inner(), readopts.inner(), cf_handle) }
     }
 
     fn get_opt<K: AsRef<[u8]>>(
@@ -1073,7 +1073,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         key: K,
         readopts: &ReadOptions,
     ) -> Result<Option<DBPinnableSlice>, Error> {
-        if readopts.inner.is_null() {
+        if readopts.inner().is_null() {
             return Err(Error::new(
                 "Unable to create RocksDB read options. This is a fairly trivial call, and its \
                  failure may be indicative of a mis-compiled or mis-loaded RocksDB library."
@@ -1085,7 +1085,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_get_pinned(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
             ));
@@ -1113,7 +1113,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         key: K,
         readopts: &ReadOptions,
     ) -> Result<Option<DBPinnableSlice>, Error> {
-        if readopts.inner.is_null() {
+        if readopts.inner().is_null() {
             return Err(Error::new(
                 "Unable to create RocksDB read options. This is a fairly trivial call, and its \
                  failure may be indicative of a mis-compiled or mis-loaded RocksDB library."
@@ -1125,7 +1125,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_get_pinned_cf(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 cf.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
@@ -1183,7 +1183,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             ffi::rocksdb_multi_get(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),
                 keys_sizes.as_ptr(),
@@ -1242,7 +1242,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             ffi::rocksdb_multi_get_cf(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 ptr_cfs.as_ptr(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),
@@ -1300,7 +1300,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             ffi::rocksdb_batched_multi_get_cf(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 cf.inner(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),
@@ -1340,7 +1340,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         unsafe {
             0 != ffi::rocksdb_key_may_exist(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
                 ptr::null_mut(), /*value*/
@@ -1370,7 +1370,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         0 != unsafe {
             ffi::rocksdb_key_may_exist_cf(
                 self.inner.inner(),
-                readopts.inner,
+                readopts.inner(),
                 cf.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
@@ -1403,7 +1403,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             != unsafe {
                 ffi::rocksdb_key_may_exist_cf(
                     self.inner.inner(),
-                    readopts.inner,
+                    readopts.inner(),
                     cf.inner(),
                     key.as_ptr() as *const c_char,
                     key.len() as size_t,

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 use std::ptr::{null_mut, NonNull};
 use std::slice;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use libc::{self, c_char, c_double, c_int, c_uchar, c_uint, c_void, size_t};
 
@@ -43,6 +43,8 @@ use crate::{
 /// Type for log callbacks used by [`Options::set_info_logger`]. Use Box to pass a thin pointer to
 /// the C callback.
 type LoggerCallback = Box<dyn Fn(LogLevel, &str) + Sync + Send>;
+
+static DEFAULT_READ_OPTIONS: LazyLock<RawReadOptions> = LazyLock::new(RawReadOptions::new);
 
 pub(crate) struct WriteBufferManagerWrapper {
     pub(crate) inner: NonNull<ffi::rocksdb_write_buffer_manager_t>,
@@ -417,8 +419,56 @@ pub struct BlockBasedOptions {
     outlive: BlockBasedOptionsMustOutliveDB,
 }
 
+struct RawReadOptions(*mut ffi::rocksdb_readoptions_t);
+
+impl RawReadOptions {
+    fn new() -> Self {
+        Self(unsafe { ffi::rocksdb_readoptions_create() })
+    }
+
+    fn as_ptr(&self) -> *const ffi::rocksdb_readoptions_t {
+        self.0
+    }
+}
+
+impl Drop for RawReadOptions {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_readoptions_destroy(self.0);
+        }
+    }
+}
+
+unsafe impl Send for RawReadOptions {}
+unsafe impl Sync for RawReadOptions {}
+
+enum ReadOptionsInner {
+    SharedDefault(&'static RawReadOptions),
+    Owned(RawReadOptions),
+}
+
+impl ReadOptionsInner {
+    fn as_ptr(&self) -> *const ffi::rocksdb_readoptions_t {
+        match self {
+            Self::SharedDefault(inner) => inner.as_ptr(),
+            Self::Owned(inner) => inner.as_ptr(),
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut ffi::rocksdb_readoptions_t {
+        if matches!(self, Self::SharedDefault(_)) {
+            *self = Self::Owned(RawReadOptions::new());
+        }
+
+        match self {
+            Self::Owned(inner) => inner.0,
+            Self::SharedDefault(_) => unreachable!(),
+        }
+    }
+}
+
 pub struct ReadOptions {
-    pub(crate) inner: *mut ffi::rocksdb_readoptions_t,
+    inner: ReadOptionsInner,
     // The `ReadOptions` owns a copy of the timestamp and iteration bounds.
     // This is necessary to ensure the pointers we pass over the FFI live as
     // long as the `ReadOptions`. This way, when performing the read operation,
@@ -559,14 +609,6 @@ impl Drop for LruCacheOptions {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_lru_cache_options_destroy(self.inner);
-        }
-    }
-}
-
-impl Drop for ReadOptions {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::rocksdb_readoptions_destroy(self.inner);
         }
     }
 }
@@ -4102,6 +4144,14 @@ pub enum CompactionPri {
 }
 
 impl ReadOptions {
+    pub(crate) fn inner(&self) -> *const ffi::rocksdb_readoptions_t {
+        self.inner.as_ptr()
+    }
+
+    fn inner_mut(&mut self) -> *mut ffi::rocksdb_readoptions_t {
+        self.inner.as_mut_ptr()
+    }
+
     // TODO add snapshot setting here
     // TODO add snapshot wrapper structs with proper destructors;
     // that struct needs an "iterator" impl too.
@@ -4113,7 +4163,7 @@ impl ReadOptions {
     /// Default: true
     pub fn fill_cache(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_fill_cache(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_fill_cache(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4122,7 +4172,7 @@ impl ReadOptions {
     /// not have been released.
     pub fn set_snapshot<D: DBAccess>(&mut self, snapshot: &SnapshotWithThreadMode<D>) {
         unsafe {
-            ffi::rocksdb_readoptions_set_snapshot(self.inner, snapshot.inner);
+            ffi::rocksdb_readoptions_set_snapshot(self.inner_mut(), snapshot.inner);
         }
     }
 
@@ -4188,7 +4238,7 @@ impl ReadOptions {
         };
         self.iterate_lower_bound = bound;
         unsafe {
-            ffi::rocksdb_readoptions_set_iterate_lower_bound(self.inner, ptr, len);
+            ffi::rocksdb_readoptions_set_iterate_lower_bound(self.inner_mut(), ptr, len);
         }
     }
 
@@ -4202,7 +4252,7 @@ impl ReadOptions {
         };
         self.iterate_upper_bound = bound;
         unsafe {
-            ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner, ptr, len);
+            ffi::rocksdb_readoptions_set_iterate_upper_bound(self.inner_mut(), ptr, len);
         }
     }
 
@@ -4213,7 +4263,7 @@ impl ReadOptions {
     /// Default: ::All
     pub fn set_read_tier(&mut self, tier: ReadTier) {
         unsafe {
-            ffi::rocksdb_readoptions_set_read_tier(self.inner, tier as c_int);
+            ffi::rocksdb_readoptions_set_read_tier(self.inner_mut(), tier as c_int);
         }
     }
 
@@ -4227,7 +4277,7 @@ impl ReadOptions {
     /// Default: false
     pub fn set_prefix_same_as_start(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_prefix_same_as_start(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_prefix_same_as_start(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4240,7 +4290,7 @@ impl ReadOptions {
     /// changing implementation of prefix extractor.
     pub fn set_total_order_seek(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_total_order_seek(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_total_order_seek(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4251,7 +4301,7 @@ impl ReadOptions {
     /// Default: 0
     pub fn set_max_skippable_internal_keys(&mut self, num: u64) {
         unsafe {
-            ffi::rocksdb_readoptions_set_max_skippable_internal_keys(self.inner, num);
+            ffi::rocksdb_readoptions_set_max_skippable_internal_keys(self.inner_mut(), num);
         }
     }
 
@@ -4262,7 +4312,7 @@ impl ReadOptions {
     pub fn set_background_purge_on_iterator_cleanup(&mut self, v: bool) {
         unsafe {
             ffi::rocksdb_readoptions_set_background_purge_on_iterator_cleanup(
-                self.inner,
+                self.inner_mut(),
                 c_uchar::from(v),
             );
         }
@@ -4277,7 +4327,7 @@ impl ReadOptions {
     )]
     pub fn set_ignore_range_deletions(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_ignore_range_deletions(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_ignore_range_deletions(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4287,7 +4337,7 @@ impl ReadOptions {
     /// Default: true
     pub fn set_verify_checksums(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_verify_checksums(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_verify_checksums(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4304,7 +4354,7 @@ impl ReadOptions {
     /// ```
     pub fn set_readahead_size(&mut self, v: usize) {
         unsafe {
-            ffi::rocksdb_readoptions_set_readahead_size(self.inner, v as size_t);
+            ffi::rocksdb_readoptions_set_readahead_size(self.inner_mut(), v as size_t);
         }
     }
 
@@ -4320,7 +4370,7 @@ impl ReadOptions {
     /// Default: true
     pub fn set_auto_readahead_size(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_auto_readahead_size(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_auto_readahead_size(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4329,7 +4379,7 @@ impl ReadOptions {
     /// or seek_to_last are not supported.
     pub fn set_tailing(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_tailing(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_tailing(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4343,7 +4393,7 @@ impl ReadOptions {
     /// Default: false
     pub fn set_pin_data(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_pin_data(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_pin_data(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4354,7 +4404,7 @@ impl ReadOptions {
     /// Default: `false`
     pub fn set_async_io(&mut self, v: bool) {
         unsafe {
-            ffi::rocksdb_readoptions_set_async_io(self.inner, c_uchar::from(v));
+            ffi::rocksdb_readoptions_set_async_io(self.inner_mut(), c_uchar::from(v));
         }
     }
 
@@ -4385,7 +4435,7 @@ impl ReadOptions {
         };
         self.timestamp = ts;
         unsafe {
-            ffi::rocksdb_readoptions_set_timestamp(self.inner, ptr, len);
+            ffi::rocksdb_readoptions_set_timestamp(self.inner_mut(), ptr, len);
         }
     }
 
@@ -4404,21 +4454,19 @@ impl ReadOptions {
         };
         self.iter_start_ts = ts;
         unsafe {
-            ffi::rocksdb_readoptions_set_iter_start_ts(self.inner, ptr, len);
+            ffi::rocksdb_readoptions_set_iter_start_ts(self.inner_mut(), ptr, len);
         }
     }
 }
 
 impl Default for ReadOptions {
     fn default() -> Self {
-        unsafe {
-            Self {
-                inner: ffi::rocksdb_readoptions_create(),
-                timestamp: None,
-                iter_start_ts: None,
-                iterate_upper_bound: None,
-                iterate_lower_bound: None,
-            }
+        Self {
+            inner: ReadOptionsInner::SharedDefault(&DEFAULT_READ_OPTIONS),
+            timestamp: None,
+            iter_start_ts: None,
+            iterate_upper_bound: None,
+            iterate_lower_bound: None,
         }
     }
 }
@@ -5033,8 +5081,34 @@ unsafe extern "C" fn logger_callback(
 
 #[cfg(test)]
 mod tests {
-    use crate::db_options::WriteBufferManager;
-    use crate::{Cache, CompactionPri, InfoLogger, MemtableFactory, Options};
+    use crate::db_options::{ReadOptions, WriteBufferManager};
+    use crate::{ffi, Cache, CompactionPri, InfoLogger, MemtableFactory, Options};
+
+    #[test]
+    fn read_options_default_is_shared_until_mutated() {
+        let default = ReadOptions::default();
+        let mut options = ReadOptions::default();
+
+        assert_eq!(default.inner(), options.inner());
+
+        // this triggers cow
+        options.fill_cache(false);
+
+        assert_ne!(default.inner(), options.inner());
+        assert_eq!(
+            unsafe { ffi::rocksdb_readoptions_get_fill_cache(default.inner().cast_mut()) },
+            1
+        );
+        assert_eq!(
+            unsafe { ffi::rocksdb_readoptions_get_fill_cache(options.inner().cast_mut()) },
+            0
+        );
+
+        // cow happens once
+        let inner = options.inner();
+        options.set_total_order_seek(true);
+        assert_eq!(inner, options.inner());
+    }
 
     #[test]
     fn test_enable_statistics() {

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -45,7 +45,7 @@ impl<DB> DBAccess for Transaction<'_, DB> {
     }
 
     unsafe fn create_iterator(&self, readopts: &ReadOptions) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_transaction_create_iterator(self.inner, readopts.inner)
+        ffi::rocksdb_transaction_create_iterator(self.inner, readopts.inner())
     }
 
     unsafe fn create_iterator_cf(
@@ -53,7 +53,7 @@ impl<DB> DBAccess for Transaction<'_, DB> {
         cf_handle: *mut ffi::rocksdb_column_family_handle_t,
         readopts: &ReadOptions,
     ) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_transaction_create_iterator_cf(self.inner, readopts.inner, cf_handle)
+        ffi::rocksdb_transaction_create_iterator_cf(self.inner, readopts.inner(), cf_handle)
     }
 
     fn get_opt<K: AsRef<[u8]>>(
@@ -325,7 +325,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transaction_get_pinned(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 key.as_ptr() as *const c_char,
                 key.len(),
             ));
@@ -364,7 +364,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transaction_get_pinned_cf(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 cf.inner(),
                 key.as_ptr() as *const c_char,
                 key.len(),
@@ -405,7 +405,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transaction_get_pinned_for_update(
                 self.inner,
-                opts.inner,
+                opts.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
                 u8::from(exclusive),
@@ -468,7 +468,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transaction_get_pinned_for_update_cf(
                 self.inner,
-                opts.inner,
+                opts.inner(),
                 cf.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
@@ -516,7 +516,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             ffi::rocksdb_transaction_multi_get(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),
                 keys_sizes.as_ptr(),
@@ -575,7 +575,7 @@ impl<DB> Transaction<'_, DB> {
         unsafe {
             ffi::rocksdb_transaction_multi_get_cf(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 ptr_cfs.as_ptr(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -98,7 +98,7 @@ impl<T: ThreadMode> DBAccess for TransactionDB<T> {
     }
 
     unsafe fn create_iterator(&self, readopts: &ReadOptions) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_transactiondb_create_iterator(self.inner, readopts.inner)
+        ffi::rocksdb_transactiondb_create_iterator(self.inner, readopts.inner())
     }
 
     unsafe fn create_iterator_cf(
@@ -106,7 +106,7 @@ impl<T: ThreadMode> DBAccess for TransactionDB<T> {
         cf_handle: *mut ffi::rocksdb_column_family_handle_t,
         readopts: &ReadOptions,
     ) -> *mut ffi::rocksdb_iterator_t {
-        ffi::rocksdb_transactiondb_create_iterator_cf(self.inner, readopts.inner, cf_handle)
+        ffi::rocksdb_transactiondb_create_iterator_cf(self.inner, readopts.inner(), cf_handle)
     }
 
     fn get_opt<K: AsRef<[u8]>>(
@@ -568,7 +568,7 @@ impl<T: ThreadMode> TransactionDB<T> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transactiondb_get_pinned(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
             ));
@@ -591,7 +591,7 @@ impl<T: ThreadMode> TransactionDB<T> {
         unsafe {
             let val = ffi_try!(ffi::rocksdb_transactiondb_get_pinned_cf(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 cf.inner(),
                 key.as_ptr() as *const c_char,
                 key.len() as size_t,
@@ -638,7 +638,7 @@ impl<T: ThreadMode> TransactionDB<T> {
         unsafe {
             ffi::rocksdb_transactiondb_multi_get(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),
                 keys_sizes.as_ptr(),
@@ -697,7 +697,7 @@ impl<T: ThreadMode> TransactionDB<T> {
         unsafe {
             ffi::rocksdb_transactiondb_multi_get_cf(
                 self.inner,
-                readopts.inner,
+                readopts.inner(),
                 ptr_cfs.as_ptr(),
                 ptr_keys.len(),
                 ptr_keys.as_ptr(),


### PR DESCRIPTION
We recently made some code that consumes a few rocks column families faster, and noticed increased jemalloc decay churn in profiles. I started profiling the relevant code and discovered quite a few unexpected allocations. The most surprising was this one:

 
<img width="1510" height="590" alt="Screenshot 2026-07-20 at 4 55 01 pm" src="https://github.com/user-attachments/assets/3014e3e9-d358-48f8-ae26-0ca9642f54c4" />

this is a 15s profile, where 15% of the allocations come from us calling `get_pinned_cf(...)` which internally does `get_pinned_cf_opt(..., &ReadOptions::default())` and turns out each `ReadOptions::default()` is a (very short lived) heap allocation.

This PR removes the allocation by making `ReadOptions::default()` return a static value, and by making `ReadOptions` copy-on-write.

The same result could be achieved by leaving `ReadOptions::default()` as is, and introducing an internal static `DEFAULT_READ_OPTIONS` or something that gets passed instead of `&ReadOptions::default()`. I have a slight preference for the CoW approach since it's self contained and works for user created `ReadOptions` instances too, but if you prefer I'm happy to switch to the other approach. 