### PR TITLE
fix(unix): preserve non-UTF-8 path bytes across FFI

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -17,7 +17,6 @@ use crate::env::Env;
 use crate::{db::DBInner, ffi, ffi_util::to_cpath, DBCommon, Error, ThreadMode};
 
 use libc::c_uchar;
-use std::ffi::CString;
 use std::path::Path;
 
 /// Represents information of a backup including timestamp of the backup
@@ -230,14 +229,7 @@ impl BackupEngineOptions {
     /// Initializes `BackupEngineOptions` with the directory to be used for storing/accessing the
     /// backup files.
     pub fn new<P: AsRef<Path>>(backup_dir: P) -> Result<Self, Error> {
-        let backup_dir = backup_dir.as_ref();
-        let c_backup_dir = CString::new(backup_dir.to_string_lossy().as_bytes()).map_err(|_| {
-            Error::new(
-                "Failed to convert backup_dir to CString \
-                     when constructing BackupEngineOptions"
-                    .to_owned(),
-            )
-        })?;
+        let c_backup_dir = to_cpath(backup_dir)?;
 
         unsafe {
             let opts = ffi::rocksdb_backup_engine_options_create(c_backup_dir.as_ptr());

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -66,12 +66,35 @@ pub fn opt_bytes_to_ptr<T: AsRef<[u8]> + ?Sized>(opt: Option<&T>) -> *const c_ch
 }
 
 pub(crate) fn to_cpath<P: AsRef<Path>>(path: P) -> Result<CString, Error> {
-    match CString::new(path.as_ref().to_string_lossy().as_bytes()) {
+    let path = path.as_ref();
+
+    #[cfg(unix)]
+    let cpath = {
+        use std::os::unix::ffi::OsStrExt;
+        CString::new(path.as_os_str().as_bytes())
+    };
+
+    #[cfg(not(unix))]
+    let cpath = CString::new(path.to_string_lossy().as_bytes());
+
+    match cpath {
         Ok(c) => Ok(c),
         Err(e) => Err(Error::new(format!(
             "Failed to convert path to CString: {e}"
         ))),
     }
+}
+
+#[cfg(all(test, unix))]
+#[test]
+fn to_cpath_preserves_non_utf8_bytes() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+    let path = Path::new(&OsString::from_vec(b"rocksdb-\xff".to_vec())).to_path_buf();
+    let cpath = to_cpath(&path).unwrap();
+
+    assert_eq!(path.as_os_str().as_bytes(), cpath.as_bytes());
 }
 
 /// Calls a RocksDB C API function that returns an error as a pointer to a C string as the last


### PR DESCRIPTION
## Summary

Preserve the original bytes of Unix paths when converting them to `CString` for RocksDB's C API.

Also make `BackupEngineOptions::new()` reuse `to_cpath()` instead of maintaining a separate path-conversion implementation.

## Problem

`to_cpath()` currently converts paths using:

```rust
CString::new(path.as_ref().to_string_lossy().as_bytes())
```

On Unix, paths are byte sequences and are not required to be valid UTF-8.

`to_string_lossy()` replaces invalid UTF-8 bytes with the UTF-8 encoding of U+FFFD.

As a result, the path passed to RocksDB may differ from the path supplied by the caller. During database opening, the Rust wrapper may create the original directory while RocksDB opens or creates the database at the lossy, rewritten path.

`BackupEngineOptions::new()`  independently performed the same lossy conversion.