### PR TITLE
Bump tikv-jemalloc-sys to 0.7

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -33,7 +33,7 @@ lto = []
 
 [dependencies]
 libc = "0.2"
-tikv-jemalloc-sys = { version = "0.6", features = [
+tikv-jemalloc-sys = { version = "0.7", features = [
     "unprefixed_malloc_on_supported_platforms",
 ], optional = true }
 lz4-sys = { version = "1.10", optional = true }


### PR DESCRIPTION
does what it says on the tin, 0.7 brings in jemalloc 5.3.1 which has a good number of improvements